### PR TITLE
FEATURE: Add edit page for personal schedules

### DIFF
--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -26,16 +26,34 @@ function PersonalScheduleForm({
   } = useForm({ defaultValues: initialPersonalSchedule || {} });
   // Stryker restore all
 
+  // let obj = {};
+  // if (initialPersonalSchedule) {
+  //   obj = {
+  //     yyyyq: initialPersonalSchedule?.quarter,
+  //     qyy:
+  //       initialPersonalSchedule?.name.substring(0, 1) +
+  //       initialPersonalSchedule?.name.substring(
+  //         initialPersonalSchedule?.name.length - 2,
+  //         initialPersonalSchedule?.name.length,
+  //       ),
+  //   }
+  // }
+  // else {
+  //   obj = {quarters: quarters,
+  //   }.quarters[0]
+  // }
   const navigate = useNavigate();
-  const [quarter, setQuarter] = useState({
-    yyyyq: initialPersonalSchedule?.quarter,
-    qyy:
-      initialPersonalSchedule?.name.substring(0, 1) +
-      initialPersonalSchedule?.name.substring(
-        initialPersonalSchedule?.name.length - 2,
-        initialPersonalSchedule?.name.length,
-      ),
-  });
+  const [quarter, setQuarter] = useState(
+    {
+      yyyyq: initialPersonalSchedule?.quarter,
+      // qyy:
+      //   initialPersonalSchedule?.name.substring(0, 1) +
+      //   initialPersonalSchedule?.name.substring(
+      //     initialPersonalSchedule?.name.length - 2,
+      //     initialPersonalSchedule?.name.length,
+      //   ),
+    }
+  );
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       {initialPersonalSchedule && (

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -8,107 +8,107 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import { useSystemInfo } from "main/utils/systemInfo";
 
 function PersonalScheduleForm({
- initialPersonalSchedule,
- submitAction,
- buttonLabel = "Create",
+  initialPersonalSchedule,
+  submitAction,
+  buttonLabel = "Create",
 }) {
- const { data: systemInfo } = useSystemInfo();
- // Stryker disable OptionalChaining
- const startQtr = systemInfo?.startQtrYYYYQ || "20211";
- const endQtr = systemInfo?.endQtrYYYYQ || "20244";
- // Stryker enable OptionalChaining
- const quarters = quarterRange(startQtr, endQtr);
- // Stryker disable all
- const {
-   register,
-   formState: { errors },
-   handleSubmit,
- } = useForm({ defaultValues: initialPersonalSchedule || {} });
- // Stryker restore all
+  const { data: systemInfo } = useSystemInfo();
+  // Stryker disable OptionalChaining
+  const startQtr = systemInfo?.startQtrYYYYQ || "20211";
+  const endQtr = systemInfo?.endQtrYYYYQ || "20244";
+  // Stryker enable OptionalChaining
+  const quarters = quarterRange(startQtr, endQtr);
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialPersonalSchedule || {} });
+  // Stryker restore all
 
+  const navigate = useNavigate();
+  const [quarter, setQuarter] = useState({
+    yyyyq: initialPersonalSchedule?.quarter,
+    qyy:
+      initialPersonalSchedule?.name.substring(0, 1) +
+      initialPersonalSchedule?.name.substring(
+        initialPersonalSchedule?.name.length - 2,
+        initialPersonalSchedule?.name.length,
+      ),
+  });
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialPersonalSchedule && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid="PersonalScheduleForm-id"
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialPersonalSchedule.id}
+            disabled
+          />
+        </Form.Group>
+      )}
 
- const navigate = useNavigate();
- const [quarter, setQuarter] = useState(
-   {
-     yyyyq: initialPersonalSchedule?.quarter,
-     qyy: initialPersonalSchedule?.name.substring(0,1) + initialPersonalSchedule?.name.substring(initialPersonalSchedule?.name.length - 2,initialPersonalSchedule?.name.length)
-   }
- );
- return (
-   <Form onSubmit={handleSubmit(submitAction)}>
-     {initialPersonalSchedule && (
-       <Form.Group className="mb-3">
-         <Form.Label htmlFor="id">Id</Form.Label>
-         <Form.Control
-           data-testid="PersonalScheduleForm-id"
-           id="id"
-           type="text"
-           {...register("id")}
-           value={initialPersonalSchedule.id}
-           disabled
-         />
-       </Form.Group>
-     )}
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="name">Name</Form.Label>
+        <Form.Control
+          data-testid="PersonalScheduleForm-name"
+          id="name"
+          type="text"
+          isInvalid={Boolean(errors.name)}
+          {...register("name", {
+            required: "Name is required.",
+            maxLength: {
+              value: 15,
+              message: "Max length 15 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.name?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
 
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="description">Description</Form.Label>
+        <Form.Control
+          data-testid="PersonalScheduleForm-description"
+          id="description"
+          type="text"
+          isInvalid={Boolean(errors.description)}
+          {...register("description", {
+            required: "Description is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.description?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+      <Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
+        <SingleQuarterDropdown
+          quarter={quarter}
+          setQuarter={setQuarter}
+          controlId={"PersonalScheduleForm-quarter"}
+          label={"Quarter"}
+          quarters={quarters}
+        />
+      </Form.Group>
 
-     <Form.Group className="mb-3">
-       <Form.Label htmlFor="name">Name</Form.Label>
-       <Form.Control
-         data-testid="PersonalScheduleForm-name"
-         id="name"
-         type="text"
-         isInvalid={Boolean(errors.name)}
-         {...register("name", {
-           required: "Name is required.",
-           maxLength: {
-             value: 15,
-             message: "Max length 15 characters",
-           },
-         })}
-       />
-       <Form.Control.Feedback type="invalid">
-         {errors.name?.message}
-       </Form.Control.Feedback>
-     </Form.Group>
-
-
-     <Form.Group className="mb-3">
-       <Form.Label htmlFor="description">Description</Form.Label>
-       <Form.Control
-         data-testid="PersonalScheduleForm-description"
-         id="description"
-         type="text"
-         isInvalid={Boolean(errors.description)}
-         {...register("description", {
-           required: "Description is required.",
-         })}
-       />
-       <Form.Control.Feedback type="invalid">
-         {errors.description?.message}
-       </Form.Control.Feedback>
-     </Form.Group>
-     <Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
-       <SingleQuarterDropdown
-         quarter={quarter}
-         setQuarter={setQuarter}
-         controlId={"PersonalScheduleForm-quarter"}
-         label={"Quarter"}
-         quarters={quarters}
-       />
-     </Form.Group>
-
-     <Button type="submit" data-testid="PersonalScheduleForm-submit">
-       {buttonLabel}
-     </Button>
-     <Button
-       variant="Secondary"
-       onClick={() => navigate(-1)}
-       data-testid="PersonalScheduleForm-cancel"
-     >
-       Cancel
-     </Button>
-   </Form>
- );
+      <Button type="submit" data-testid="PersonalScheduleForm-submit">
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid="PersonalScheduleForm-cancel"
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
 }
 
 export default PersonalScheduleForm;

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -15,7 +15,7 @@ function PersonalScheduleForm({
   const { data: systemInfo } = useSystemInfo();
   // Stryker disable OptionalChaining
   const startQtr = systemInfo?.startQtrYYYYQ || "20211";
-  const endQtr = systemInfo?.endQtrYYYYQ || "20244";
+  const endQtr = systemInfo?.endQtrYYYYQ || "20214";
   // Stryker enable OptionalChaining
   const quarters = quarterRange(startQtr, endQtr);
   // Stryker disable all

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -8,105 +8,107 @@ import { quarterRange } from "main/utils/quarterUtilities";
 import { useSystemInfo } from "main/utils/systemInfo";
 
 function PersonalScheduleForm({
-  initialPersonalSchedule,
-  submitAction,
-  buttonLabel = "Create",
+ initialPersonalSchedule,
+ submitAction,
+ buttonLabel = "Create",
 }) {
-  const { data: systemInfo } = useSystemInfo();
-  // Stryker disable OptionalChaining
-  const startQtr = systemInfo?.startQtrYYYYQ || "20211";
-  const endQtr = systemInfo?.endQtrYYYYQ || "20214";
-  // Stryker enable OptionalChaining
-  const quarters = quarterRange(startQtr, endQtr);
+ const { data: systemInfo } = useSystemInfo();
+ // Stryker disable OptionalChaining
+ const startQtr = systemInfo?.startQtrYYYYQ || "20211";
+ const endQtr = systemInfo?.endQtrYYYYQ || "20244";
+ // Stryker enable OptionalChaining
+ const quarters = quarterRange(startQtr, endQtr);
+ // Stryker disable all
+ const {
+   register,
+   formState: { errors },
+   handleSubmit,
+ } = useForm({ defaultValues: initialPersonalSchedule || {} });
+ // Stryker restore all
 
-  // Stryker disable all
-  const {
-    register,
-    formState: { errors },
-    handleSubmit,
-  } = useForm({ defaultValues: initialPersonalSchedule || {} });
-  // Stryker restore all
 
-  const navigate = useNavigate();
-  const [quarter, setQuarter] = useState(
-    {
-      quarters: quarters,
-    }.quarters[0],
-  );
+ const navigate = useNavigate();
+ const [quarter, setQuarter] = useState(
+   {
+     yyyyq: initialPersonalSchedule?.quarter,
+     qyy: initialPersonalSchedule?.name.substring(0,1) + initialPersonalSchedule?.name.substring(initialPersonalSchedule?.name.length - 2,initialPersonalSchedule?.name.length)
+   }
+ );
+ return (
+   <Form onSubmit={handleSubmit(submitAction)}>
+     {initialPersonalSchedule && (
+       <Form.Group className="mb-3">
+         <Form.Label htmlFor="id">Id</Form.Label>
+         <Form.Control
+           data-testid="PersonalScheduleForm-id"
+           id="id"
+           type="text"
+           {...register("id")}
+           value={initialPersonalSchedule.id}
+           disabled
+         />
+       </Form.Group>
+     )}
 
-  return (
-    <Form onSubmit={handleSubmit(submitAction)}>
-      {initialPersonalSchedule && (
-        <Form.Group className="mb-3">
-          <Form.Label htmlFor="id">Id</Form.Label>
-          <Form.Control
-            data-testid="PersonalScheduleForm-id"
-            id="id"
-            type="text"
-            {...register("id")}
-            value={initialPersonalSchedule.id}
-            disabled
-          />
-        </Form.Group>
-      )}
 
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="name">Name</Form.Label>
-        <Form.Control
-          data-testid="PersonalScheduleForm-name"
-          id="name"
-          type="text"
-          isInvalid={Boolean(errors.name)}
-          {...register("name", {
-            required: "Name is required.",
-            maxLength: {
-              value: 15,
-              message: "Max length 15 characters",
-            },
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.name?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
+     <Form.Group className="mb-3">
+       <Form.Label htmlFor="name">Name</Form.Label>
+       <Form.Control
+         data-testid="PersonalScheduleForm-name"
+         id="name"
+         type="text"
+         isInvalid={Boolean(errors.name)}
+         {...register("name", {
+           required: "Name is required.",
+           maxLength: {
+             value: 15,
+             message: "Max length 15 characters",
+           },
+         })}
+       />
+       <Form.Control.Feedback type="invalid">
+         {errors.name?.message}
+       </Form.Control.Feedback>
+     </Form.Group>
 
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="description">Description</Form.Label>
-        <Form.Control
-          data-testid="PersonalScheduleForm-description"
-          id="description"
-          type="text"
-          isInvalid={Boolean(errors.description)}
-          {...register("description", {
-            required: "Description is required.",
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.description?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
-      <Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
-        <SingleQuarterDropdown
-          quarter={quarter}
-          setQuarter={setQuarter}
-          controlId={"PersonalScheduleForm-quarter"}
-          label={"Quarter"}
-          quarters={quarters}
-        />
-      </Form.Group>
 
-      <Button type="submit" data-testid="PersonalScheduleForm-submit">
-        {buttonLabel}
-      </Button>
-      <Button
-        variant="Secondary"
-        onClick={() => navigate(-1)}
-        data-testid="PersonalScheduleForm-cancel"
-      >
-        Cancel
-      </Button>
-    </Form>
-  );
+     <Form.Group className="mb-3">
+       <Form.Label htmlFor="description">Description</Form.Label>
+       <Form.Control
+         data-testid="PersonalScheduleForm-description"
+         id="description"
+         type="text"
+         isInvalid={Boolean(errors.description)}
+         {...register("description", {
+           required: "Description is required.",
+         })}
+       />
+       <Form.Control.Feedback type="invalid">
+         {errors.description?.message}
+       </Form.Control.Feedback>
+     </Form.Group>
+     <Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
+       <SingleQuarterDropdown
+         quarter={quarter}
+         setQuarter={setQuarter}
+         controlId={"PersonalScheduleForm-quarter"}
+         label={"Quarter"}
+         quarters={quarters}
+       />
+     </Form.Group>
+
+     <Button type="submit" data-testid="PersonalScheduleForm-submit">
+       {buttonLabel}
+     </Button>
+     <Button
+       variant="Secondary"
+       onClick={() => navigate(-1)}
+       data-testid="PersonalScheduleForm-cancel"
+     >
+       Cancel
+     </Button>
+   </Form>
+ );
 }
 
 export default PersonalScheduleForm;

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -26,9 +26,17 @@ function PersonalScheduleForm({
   } = useForm({ defaultValues: initialPersonalSchedule || {} });
   // Stryker restore all
   const navigate = useNavigate();
-  const [quarter, setQuarter] = useState({
-    yyyyq: initialPersonalSchedule?.quarter,
-  });
+  const [quarter, setQuarter] = useState(
+    {
+      quarters: quarters,
+    }.quarters[0],
+  );
+  const quarterMap = {
+    '1': 'W',
+    '2': 'S',
+    '3': 'M',
+    '4': 'F'
+  }
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       {initialPersonalSchedule && (
@@ -80,7 +88,20 @@ function PersonalScheduleForm({
           {errors.description?.message}
         </Form.Control.Feedback>
       </Form.Group>
-      <Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
+      
+      {initialPersonalSchedule ? (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="quarter">Quarter</Form.Label>
+          <Form.Control
+            data-testid="PersonalScheduleForm-quarter"
+            id="quarter"
+            type="text"
+            {...register("quarter")}
+            value={quarterMap[initialPersonalSchedule.quarter.substring(4,5)] + initialPersonalSchedule.quarter.substring(2,4)}
+            disabled
+          />
+        </Form.Group>
+      ) : (<Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
         <SingleQuarterDropdown
           quarter={quarter}
           setQuarter={setQuarter}
@@ -88,7 +109,7 @@ function PersonalScheduleForm({
           label={"Quarter"}
           quarters={quarters}
         />
-      </Form.Group>
+      </Form.Group>)}
 
       <Button type="submit" data-testid="PersonalScheduleForm-submit">
         {buttonLabel}

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -25,35 +25,10 @@ function PersonalScheduleForm({
     handleSubmit,
   } = useForm({ defaultValues: initialPersonalSchedule || {} });
   // Stryker restore all
-
-  // let obj = {};
-  // if (initialPersonalSchedule) {
-  //   obj = {
-  //     yyyyq: initialPersonalSchedule?.quarter,
-  //     qyy:
-  //       initialPersonalSchedule?.name.substring(0, 1) +
-  //       initialPersonalSchedule?.name.substring(
-  //         initialPersonalSchedule?.name.length - 2,
-  //         initialPersonalSchedule?.name.length,
-  //       ),
-  //   }
-  // }
-  // else {
-  //   obj = {quarters: quarters,
-  //   }.quarters[0]
-  // }
   const navigate = useNavigate();
-  const [quarter, setQuarter] = useState(
-    {
-      yyyyq: initialPersonalSchedule?.quarter,
-      // qyy:
-      //   initialPersonalSchedule?.name.substring(0, 1) +
-      //   initialPersonalSchedule?.name.substring(
-      //     initialPersonalSchedule?.name.length - 2,
-      //     initialPersonalSchedule?.name.length,
-      //   ),
-    }
-  );
+  const [quarter, setQuarter] = useState({
+    yyyyq: initialPersonalSchedule?.quarter,
+  });
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       {initialPersonalSchedule && (

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -32,11 +32,11 @@ function PersonalScheduleForm({
     }.quarters[0],
   );
   const quarterMap = {
-    '1': 'W',
-    '2': 'S',
-    '3': 'M',
-    '4': 'F'
-  }
+    1: "W",
+    2: "S",
+    3: "M",
+    4: "F",
+  };
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       {initialPersonalSchedule && (
@@ -88,7 +88,7 @@ function PersonalScheduleForm({
           {errors.description?.message}
         </Form.Control.Feedback>
       </Form.Group>
-      
+
       {initialPersonalSchedule ? (
         <Form.Group className="mb-3">
           <Form.Label htmlFor="quarter">Quarter</Form.Label>
@@ -97,19 +97,24 @@ function PersonalScheduleForm({
             id="quarter"
             type="text"
             {...register("quarter")}
-            value={quarterMap[initialPersonalSchedule.quarter.substring(4,5)] + initialPersonalSchedule.quarter.substring(2,4)}
+            value={
+              quarterMap[initialPersonalSchedule.quarter.substring(4, 5)] +
+              initialPersonalSchedule.quarter.substring(2, 4)
+            }
             disabled
           />
         </Form.Group>
-      ) : (<Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
-        <SingleQuarterDropdown
-          quarter={quarter}
-          setQuarter={setQuarter}
-          controlId={"PersonalScheduleForm-quarter"}
-          label={"Quarter"}
-          quarters={quarters}
-        />
-      </Form.Group>)}
+      ) : (
+        <Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
+          <SingleQuarterDropdown
+            quarter={quarter}
+            setQuarter={setQuarter}
+            controlId={"PersonalScheduleForm-quarter"}
+            label={"Quarter"}
+            quarters={quarters}
+          />
+        </Form.Group>
+      )}
 
       <Button type="submit" data-testid="PersonalScheduleForm-submit">
         {buttonLabel}

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -25,7 +25,7 @@ function SingleQuarterDropdown({
   if (!localSearchQuarter) {
     localStorage.setItem(controlId, quarters[0].yyyyq);
   }
-
+  console.log(localSearchQuarter);
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
     //localSearchQuarter || quarters[0].yyyyq,

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -14,54 +14,53 @@ import { Form } from "react-bootstrap";
 //  { yyyyq :"20222", qyy: "S22"}]
 
 function SingleQuarterDropdown({
- quarter,
- quarters,
- setQuarter,
- controlId,
- onChange = null,
- label = "Quarter",
+  quarter,
+  quarters,
+  setQuarter,
+  controlId,
+  onChange = null,
+  label = "Quarter",
 }) {
- const localSearchQuarter = localStorage.getItem(controlId);
- if (!localSearchQuarter) {
-   localStorage.setItem(controlId, quarters[0].yyyyq);
- }
- const [quarterState, setQuarterState] = useState(
-   // Stryker disable next-line all : not sure how to test/mock local storage
-   //localSearchQuarter || quarters[0].yyyyq,
-   quarter.yyyyq || localSearchQuarter
- );
+  const localSearchQuarter = localStorage.getItem(controlId);
+  if (!localSearchQuarter) {
+    localStorage.setItem(controlId, quarters[0].yyyyq);
+  }
 
+  const [quarterState, setQuarterState] = useState(
+    // Stryker disable next-line all : not sure how to test/mock local storage
+    //localSearchQuarter || quarters[0].yyyyq,
+    quarter.yyyyq || localSearchQuarter || quarters[0].yyyyq,
+  );
 
- const handleQuarterOnChange = (event) => {
-   const selectedQuarter = event.target.value;
-   localStorage.setItem(controlId, selectedQuarter);
-   setQuarterState(selectedQuarter);
-   setQuarter(selectedQuarter);
-   if (onChange != null) {
-     onChange(event);
-   }
- };
+  const handleQuarterOnChange = (event) => {
+    const selectedQuarter = event.target.value;
+    localStorage.setItem(controlId, selectedQuarter);
+    setQuarterState(selectedQuarter);
+    setQuarter(selectedQuarter);
+    if (onChange != null) {
+      onChange(event);
+    }
+  };
 
- return (
-   <Form.Group controlId={controlId}>
-     <Form.Label>{label}</Form.Label>
-     <Form.Control
-       as="select"
-       value={quarterState}
-       onChange={handleQuarterOnChange}
-     >
-       {quarters.map(function (object, i) {
-         const key = `${controlId}-option-${i}`;
-         return (
-           <option key={key} data-testid={key} value={object.yyyyq}>
-             {object.qyy}
-           </option>
-         );
-       })}
-     </Form.Control>
-   </Form.Group>
- );
+  return (
+    <Form.Group controlId={controlId}>
+      <Form.Label>{label}</Form.Label>
+      <Form.Control
+        as="select"
+        value={quarterState}
+        onChange={handleQuarterOnChange}
+      >
+        {quarters.map(function (object, i) {
+          const key = `${controlId}-option-${i}`;
+          return (
+            <option key={key} data-testid={key} value={object.yyyyq}>
+              {object.qyy}
+            </option>
+          );
+        })}
+      </Form.Control>
+    </Form.Group>
+  );
 }
-
 
 export default SingleQuarterDropdown;

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -25,7 +25,6 @@ function SingleQuarterDropdown({
   if (!localSearchQuarter) {
     localStorage.setItem(controlId, quarters[0].yyyyq);
   }
-  console.log(localSearchQuarter);
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
     //localSearchQuarter || quarters[0].yyyyq,

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -14,51 +14,54 @@ import { Form } from "react-bootstrap";
 //  { yyyyq :"20222", qyy: "S22"}]
 
 function SingleQuarterDropdown({
-  quarters,
-  setQuarter,
-  controlId,
-  onChange = null,
-  label = "Quarter",
+ quarter,
+ quarters,
+ setQuarter,
+ controlId,
+ onChange = null,
+ label = "Quarter",
 }) {
-  const localSearchQuarter = localStorage.getItem(controlId);
-  if (!localSearchQuarter) {
-    localStorage.setItem(controlId, quarters[0].yyyyq);
-  }
+ const localSearchQuarter = localStorage.getItem(controlId);
+ if (!localSearchQuarter) {
+   localStorage.setItem(controlId, quarters[0].yyyyq);
+ }
+ const [quarterState, setQuarterState] = useState(
+   // Stryker disable next-line all : not sure how to test/mock local storage
+   //localSearchQuarter || quarters[0].yyyyq,
+   quarter.yyyyq || localSearchQuarter
+ );
 
-  const [quarterState, setQuarterState] = useState(
-    // Stryker disable next-line all : not sure how to test/mock local storage
-    localSearchQuarter || quarters[0].yyyyq,
-  );
 
-  const handleQuarterOnChange = (event) => {
-    const selectedQuarter = event.target.value;
-    localStorage.setItem(controlId, selectedQuarter);
-    setQuarterState(selectedQuarter);
-    setQuarter(selectedQuarter);
-    if (onChange != null) {
-      onChange(event);
-    }
-  };
+ const handleQuarterOnChange = (event) => {
+   const selectedQuarter = event.target.value;
+   localStorage.setItem(controlId, selectedQuarter);
+   setQuarterState(selectedQuarter);
+   setQuarter(selectedQuarter);
+   if (onChange != null) {
+     onChange(event);
+   }
+ };
 
-  return (
-    <Form.Group controlId={controlId}>
-      <Form.Label>{label}</Form.Label>
-      <Form.Control
-        as="select"
-        value={quarterState}
-        onChange={handleQuarterOnChange}
-      >
-        {quarters.map(function (object, i) {
-          const key = `${controlId}-option-${i}`;
-          return (
-            <option key={key} data-testid={key} value={object.yyyyq}>
-              {object.qyy}
-            </option>
-          );
-        })}
-      </Form.Control>
-    </Form.Group>
-  );
+ return (
+   <Form.Group controlId={controlId}>
+     <Form.Label>{label}</Form.Label>
+     <Form.Control
+       as="select"
+       value={quarterState}
+       onChange={handleQuarterOnChange}
+     >
+       {quarters.map(function (object, i) {
+         const key = `${controlId}-option-${i}`;
+         return (
+           <option key={key} data-testid={key} value={object.yyyyq}>
+             {object.qyy}
+           </option>
+         );
+       })}
+     </Form.Control>
+   </Form.Group>
+ );
 }
+
 
 export default SingleQuarterDropdown;

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -39,6 +39,7 @@ export default function PersonalSchedulesEditPage({storybook=false}) {
       toast(
         `PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name}`,
       );
+      console.log(personalSchedule.quarter);
     };
 
     const mutation = useBackendMutation(
@@ -51,7 +52,13 @@ export default function PersonalSchedulesEditPage({storybook=false}) {
     const { isSuccess } = mutation
 
     const onSubmit = async (data) => {
-        mutation.mutate(data);
+        const quarter = {
+            quarter: localStorage["PersonalScheduleForm-quarter"],
+        };
+        console.log(quarter);
+        const dataFinal = Object.assign(data, quarter);
+        console.log(dataFinal);
+        mutation.mutate(dataFinal);
     }
 
     if (isSuccess && !storybook) {

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -37,7 +37,7 @@ export default function PersonalSchedulesEditPage({storybook=false}) {
 
     const onSuccess = (personalSchedule) => {
       toast(
-        `New personalSchedule Created - id: ${personalSchedule.id} name: ${personalSchedule.name}`,
+        `PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name}`,
       );
     };
 

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -39,9 +39,9 @@ export default function PersonalSchedulesEditPage({ storybook = false }) {
       // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
       method: "GET",
       url: `/api/courses/user/psid/all?psId=${id}`,
-      params: {
-        id,
-      },
+      // params: {
+      //   id,
+      // },
     },
     [],
   );

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -1,6 +1,7 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
 import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
+import PersonalSectionsTable from "main/components/PersonalSections/PersonalSectionsTable";
 import { Navigate } from "react-router-dom";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
@@ -19,6 +20,18 @@ export default function PersonalSchedulesEditPage({ storybook = false }) {
       // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
       method: "GET",
       url: `/api/personalschedules`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const { data: personalSection } = useBackend(
+    // Stryker disable all : hard to test for query caching
+    [`/api/personalSections/all?psId=${id}`],
+    {
+      method: "GET",
+      url: `/api/personalSections/all?psId=${id}`,
       params: {
         id,
       },
@@ -80,6 +93,12 @@ export default function PersonalSchedulesEditPage({ storybook = false }) {
             initialPersonalSchedule={personalSchedule}
           />
         )}
+        <p>
+          <h2>Sections in Personal Schedule</h2>
+          {personalSection && (
+            <PersonalSectionsTable personalSections={personalSection} />
+          )}
+        </p>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -77,13 +77,7 @@ export default function PersonalSchedulesEditPage({ storybook = false }) {
   const { isSuccess } = mutation;
 
   const onSubmit = async (data) => {
-    const quarter = {
-      quarter: localStorage["PersonalScheduleForm-quarter"],
-    };
-    console.log(quarter);
-    const dataFinal = Object.assign(data, quarter);
-    console.log(dataFinal);
-    mutation.mutate(dataFinal);
+    mutation.mutate(data);
   };
 
   if (isSuccess && !storybook) {

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -1,18 +1,20 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
 import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
-import PersonalSectionsTable from "main/components/PersonalSections/PersonalSectionsTable";
+import CourseTable from "main/components/Courses/CourseTable";
 import { Navigate } from "react-router-dom";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
+import { useCurrentUser } from "main/utils/currentUser";
 
 export default function PersonalSchedulesEditPage({ storybook = false }) {
   let { id } = useParams();
+  const currentUser = useCurrentUser();
 
   const {
     data: personalSchedule,
-    _error,
-    _status,
+    _PSerror,
+    _PSstatus,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
     [`/api/personalschedules?id=${id}`],
@@ -26,16 +28,22 @@ export default function PersonalSchedulesEditPage({ storybook = false }) {
     },
   );
 
-  const { data: personalSection } = useBackend(
-    // Stryker disable all : hard to test for query caching
-    [`/api/personalSections/all?psId=${id}`],
+  const {
+    data: courses,
+    error: _PCerror,
+    status: _PCstatus,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/courses/user/psid/all?psId=${id}`],
     {
+      // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
       method: "GET",
-      url: `/api/personalSections/all?psId=${id}`,
+      url: `/api/courses/user/psid/all?psId=${id}`,
       params: {
         id,
       },
     },
+    [],
   );
 
   const objectToAxiosPutParams = (personalSchedule) => ({
@@ -93,11 +101,9 @@ export default function PersonalSchedulesEditPage({ storybook = false }) {
             initialPersonalSchedule={personalSchedule}
           />
         )}
-        <p>
-          <h2>Sections in Personal Schedule</h2>
-          {personalSection && (
-            <PersonalSectionsTable personalSections={personalSection} />
-          )}
+        <p className="py-5">
+          <h1>Courses</h1>
+          <CourseTable courses={courses} currentUser={currentUser} />
         </p>
       </div>
     </BasicLayout>

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -1,79 +1,95 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
 import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
-import { Navigate } from 'react-router-dom'
+import { Navigate } from "react-router-dom";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
-export default function PersonalSchedulesEditPage({storybook=false}) {
-    let { id } = useParams();
 
-    const { data: personalSchedule, _error, _status } =
-        useBackend(
-            // Stryker disable next-line all : don't test internal caching of React Query
-            [`/api/personalschedules?id=${id}`],
-            {  // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
-                method: "GET",
-                url: `/api/personalschedules`,
-                params: {
-                    id
-                }
-            }
-        );
+export default function PersonalSchedulesEditPage({ storybook = false }) {
+ let { id } = useParams();
 
-    const objectToAxiosPutParams = (personalSchedule) => ({
-        url: "/api/personalschedules",
-        method: "PUT",
-        params: {
-            id: personalSchedule.id,
-        },
-        data: {
-            user: personalSchedule.user,
-            name: personalSchedule.name,
-            description: personalSchedule.description,
-            quarter: personalSchedule.quarter
-        }
-    });
 
-    const onSuccess = (personalSchedule) => {
-      toast(
-        `PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name}`,
-      );
-      console.log(personalSchedule.quarter);
-    };
+ const {
+   data: personalSchedule,
+   _error,
+   _status,
+ } = useBackend(
+   // Stryker disable next-line all : don't test internal caching of React Query
+   [`/api/personalschedules?id=${id}`],
+   {
+     // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+     method: "GET",
+     url: `/api/personalschedules`,
+     params: {
+       id,
+     },
+   },
+ );
 
-    const mutation = useBackendMutation(
-        objectToAxiosPutParams,
-        { onSuccess },
-        // Stryker disable next-line all : hard to set up test for caching
-        [`/api/personalschedules?id=${id}`]
-    );
 
-    const { isSuccess } = mutation
+ const objectToAxiosPutParams = (personalSchedule) => ({
+   url: "/api/personalschedules",
+   method: "PUT",
+   params: {
+     id: personalSchedule.id,
+   },
+   data: {
+     user: personalSchedule.user,
+     name: personalSchedule.name,
+     description: personalSchedule.description,
+     quarter: personalSchedule.quarter,
+   },
+ });
 
-    const onSubmit = async (data) => {
-        const quarter = {
-            quarter: localStorage["PersonalScheduleForm-quarter"],
-        };
-        console.log(quarter);
-        const dataFinal = Object.assign(data, quarter);
-        console.log(dataFinal);
-        mutation.mutate(dataFinal);
-    }
 
-    if (isSuccess && !storybook) {
-        return <Navigate to="/personalschedules/list" />
-    }
+ const onSuccess = (personalSchedule) => {
+   toast(
+     `PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name}`,
+   );
+   console.log(personalSchedule.quarter);
+ };
 
-    return (
-        <BasicLayout>
-            <div className="pt-2">
-                <h1>Edit Personal Schedule</h1>
-                {
-                    personalSchedule && <PersonalScheduleForm submitAction={onSubmit} buttonLabel={"Update"} initialPersonalSchedule={personalSchedule} />
-                }
-            </div>
-        </BasicLayout>
-    )
 
+ const mutation = useBackendMutation(
+   objectToAxiosPutParams,
+   { onSuccess },
+   // Stryker disable next-line all : hard to set up test for caching
+   [`/api/personalschedules?id=${id}`],
+ );
+
+
+ const { isSuccess } = mutation;
+
+
+ const onSubmit = async (data) => {
+   const quarter = {
+     quarter: localStorage["PersonalScheduleForm-quarter"],
+   };
+   console.log(quarter);
+   const dataFinal = Object.assign(data, quarter);
+   console.log(dataFinal);
+   mutation.mutate(dataFinal);
+ };
+
+
+ if (isSuccess && !storybook) {
+   return <Navigate to="/personalschedules/list" />;
+ }
+
+
+ return (
+   <BasicLayout>
+     <div className="pt-2">
+       <h1>Edit Personal Schedule</h1>
+       {personalSchedule && (
+         <PersonalScheduleForm
+           submitAction={onSubmit}
+           buttonLabel={"Update"}
+           initialPersonalSchedule={personalSchedule}
+         />
+       )}
+     </div>
+   </BasicLayout>
+ );
 }

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -1,12 +1,72 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function PersonalSchedulesEditPage() {
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Personal Schedules</h1>
-        <p>This is where the edit page will go</p>
-      </div>
-    </BasicLayout>
-  );
+export default function PersonalSchedulesEditPage({storybook=false}) {
+    let { id } = useParams();
+
+    const { data: personalSchedule, _error, _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/personalschedules?id=${id}`],
+            {  // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/personalschedules`,
+                params: {
+                    id
+                }
+            }
+        );
+
+    const objectToAxiosPutParams = (personalSchedule) => ({
+        url: "/api/personalschedules",
+        method: "PUT",
+        params: {
+            id: personalSchedule.id,
+        },
+        data: {
+            user: personalSchedule.user,
+            name: personalSchedule.name,
+            description: personalSchedule.description,
+            quarter: personalSchedule.quarter
+        }
+    });
+
+    const onSuccess = (personalSchedule) => {
+      toast(
+        `New personalSchedule Created - id: ${personalSchedule.id} name: ${personalSchedule.name}`,
+      );
+    };
+
+    const mutation = useBackendMutation(
+        objectToAxiosPutParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        [`/api/personalschedules?id=${id}`]
+    );
+
+    const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    }
+
+    if (isSuccess && !storybook) {
+        return <Navigate to="/personalschedules/list" />
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Edit Personal Schedule</h1>
+                {
+                    personalSchedule && <PersonalScheduleForm submitAction={onSubmit} buttonLabel={"Update"} initialPersonalSchedule={personalSchedule} />
+                }
+            </div>
+        </BasicLayout>
+    )
+
 }

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -5,91 +5,82 @@ import { Navigate } from "react-router-dom";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
-
 export default function PersonalSchedulesEditPage({ storybook = false }) {
- let { id } = useParams();
+  let { id } = useParams();
 
+  const {
+    data: personalSchedule,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/personalschedules?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/personalschedules`,
+      params: {
+        id,
+      },
+    },
+  );
 
- const {
-   data: personalSchedule,
-   _error,
-   _status,
- } = useBackend(
-   // Stryker disable next-line all : don't test internal caching of React Query
-   [`/api/personalschedules?id=${id}`],
-   {
-     // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
-     method: "GET",
-     url: `/api/personalschedules`,
-     params: {
-       id,
-     },
-   },
- );
+  const objectToAxiosPutParams = (personalSchedule) => ({
+    url: "/api/personalschedules",
+    method: "PUT",
+    params: {
+      id: personalSchedule.id,
+    },
+    data: {
+      user: personalSchedule.user,
+      name: personalSchedule.name,
+      description: personalSchedule.description,
+      quarter: personalSchedule.quarter,
+    },
+  });
 
+  const onSuccess = (personalSchedule) => {
+    toast(
+      `PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name}`,
+    );
+    console.log(personalSchedule.quarter);
+  };
 
- const objectToAxiosPutParams = (personalSchedule) => ({
-   url: "/api/personalschedules",
-   method: "PUT",
-   params: {
-     id: personalSchedule.id,
-   },
-   data: {
-     user: personalSchedule.user,
-     name: personalSchedule.name,
-     description: personalSchedule.description,
-     quarter: personalSchedule.quarter,
-   },
- });
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/personalschedules?id=${id}`],
+  );
 
+  const { isSuccess } = mutation;
 
- const onSuccess = (personalSchedule) => {
-   toast(
-     `PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name}`,
-   );
-   console.log(personalSchedule.quarter);
- };
+  const onSubmit = async (data) => {
+    const quarter = {
+      quarter: localStorage["PersonalScheduleForm-quarter"],
+    };
+    console.log(quarter);
+    const dataFinal = Object.assign(data, quarter);
+    console.log(dataFinal);
+    mutation.mutate(dataFinal);
+  };
 
+  if (isSuccess && !storybook) {
+    return <Navigate to="/personalschedules/list" />;
+  }
 
- const mutation = useBackendMutation(
-   objectToAxiosPutParams,
-   { onSuccess },
-   // Stryker disable next-line all : hard to set up test for caching
-   [`/api/personalschedules?id=${id}`],
- );
-
-
- const { isSuccess } = mutation;
-
-
- const onSubmit = async (data) => {
-   const quarter = {
-     quarter: localStorage["PersonalScheduleForm-quarter"],
-   };
-   console.log(quarter);
-   const dataFinal = Object.assign(data, quarter);
-   console.log(dataFinal);
-   mutation.mutate(dataFinal);
- };
-
-
- if (isSuccess && !storybook) {
-   return <Navigate to="/personalschedules/list" />;
- }
-
-
- return (
-   <BasicLayout>
-     <div className="pt-2">
-       <h1>Edit Personal Schedule</h1>
-       {personalSchedule && (
-         <PersonalScheduleForm
-           submitAction={onSubmit}
-           buttonLabel={"Update"}
-           initialPersonalSchedule={personalSchedule}
-         />
-       )}
-     </div>
-   </BasicLayout>
- );
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit Personal Schedule</h1>
+        {personalSchedule && (
+          <PersonalScheduleForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialPersonalSchedule={personalSchedule}
+          />
+        )}
+      </div>
+    </BasicLayout>
+  );
 }

--- a/frontend/src/stories/pages/HomePage/PersonalSchedules/PersonalSchedulesEditPage.stories.js
+++ b/frontend/src/stories/pages/HomePage/PersonalSchedules/PersonalSchedulesEditPage.stories.js
@@ -1,35 +1,10 @@
 import React from "react";
 
-import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
-import { rest } from "msw";
-
 export default {
   title: "pages/PersonalSchedules/PersonalSchedulesEditPage",
   component: PersonalSchedulesEditPage,
 };
 
-const Template = () => <PersonalSchedulesEditPage storybook={true}/>;
+const Template = () => <PersonalSchedulesEditPage storybook={true} />;
 
 export const Default = Template.bind({});
-
-Default.parameters = {
-    msw: [
-        rest.get('/api/currentUser', (_req, res, ctx) => {
-            return res( ctx.json(apiCurrentUserFixtures.userOnly));
-        }),
-        rest.get('/api/systemInfo', (_req, res, ctx) => {
-            return res(ctx.json(systemInfoFixtures.showingNeither));
-        }),
-        rest.get('/api/personalschedules', (_req, res, ctx) => {
-            return res(ctx.json(personalScheduleFixtures.threePersonalSchedules[0]));
-        }),
-        rest.put('/api/personalschedules', async (req, res, ctx) => {
-            var reqBody = await req.text();
-            window.alert("PUT: " + req.url + " and body: " + reqBody);
-            return res(ctx.status(200),ctx.json({}));
-        }),
-    ],
-}

--- a/frontend/src/stories/pages/HomePage/PersonalSchedules/PersonalSchedulesEditPage.stories.js
+++ b/frontend/src/stories/pages/HomePage/PersonalSchedules/PersonalSchedulesEditPage.stories.js
@@ -1,5 +1,7 @@
 import React from "react";
 
+import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
+
 export default {
   title: "pages/PersonalSchedules/PersonalSchedulesEditPage",
   component: PersonalSchedulesEditPage,

--- a/frontend/src/stories/pages/HomePage/PersonalSchedules/PersonalSchedulesEditPage.stories.js
+++ b/frontend/src/stories/pages/HomePage/PersonalSchedules/PersonalSchedulesEditPage.stories.js
@@ -1,12 +1,35 @@
 import React from "react";
 
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
+import { rest } from "msw";
 
 export default {
   title: "pages/PersonalSchedules/PersonalSchedulesEditPage",
   component: PersonalSchedulesEditPage,
 };
 
-const Template = () => <PersonalSchedulesEditPage />;
+const Template = () => <PersonalSchedulesEditPage storybook={true}/>;
 
 export const Default = Template.bind({});
+
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/personalschedules', (_req, res, ctx) => {
+            return res(ctx.json(personalScheduleFixtures.threePersonalSchedules[0]));
+        }),
+        rest.put('/api/personalschedules', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -226,9 +226,9 @@ describe("PersonalScheduleForm tests", () => {
       </QueryClientProvider>,
     );
     await waitFor(() => {
-      expect(
-        screen.getByTestId("PersonalScheduleForm-quarter"),
-      ).toHaveValue("S22");
+      expect(screen.getByTestId("PersonalScheduleForm-quarter")).toHaveValue(
+        "S22",
+      );
     });
   });
   test("Form has initialPersonalSchedule content with Fall quarter", async () => {
@@ -261,9 +261,9 @@ describe("PersonalScheduleForm tests", () => {
       </QueryClientProvider>,
     );
     await waitFor(() => {
-      expect(
-        screen.getByTestId("PersonalScheduleForm-quarter"),
-      ).toHaveValue("F22");
+      expect(screen.getByTestId("PersonalScheduleForm-quarter")).toHaveValue(
+        "F22",
+      );
     });
   });
   test("Form has initialPersonalSchedule content with M quarter", async () => {
@@ -296,9 +296,9 @@ describe("PersonalScheduleForm tests", () => {
       </QueryClientProvider>,
     );
     await waitFor(() => {
-      expect(
-        screen.getByTestId("PersonalScheduleForm-quarter"),
-      ).toHaveValue("M22");
+      expect(screen.getByTestId("PersonalScheduleForm-quarter")).toHaveValue(
+        "M22",
+      );
     });
   });
 });

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -217,7 +217,7 @@ describe("PersonalScheduleForm tests", () => {
       description: "My Plan for Fall",
       quarter: "20222",
       name: "Fall Courses",
-    }
+    };
     render(
       <QueryClientProvider client={queryClient}>
         <Router>
@@ -226,11 +226,9 @@ describe("PersonalScheduleForm tests", () => {
       </QueryClientProvider>,
     );
     await waitFor(() => {
-      expect(document.querySelector("#PersonalScheduleForm-quarter")).toHaveValue("20222");
+      expect(
+        document.querySelector("#PersonalScheduleForm-quarter"),
+      ).toHaveValue("20222");
     });
-    console.log("HERE ", document.querySelector("#PersonalScheduleForm-quarter"));
-    // await waitFor(() => {
-    //   expect(screen.getByText("#PersonalScheduleForm-quarter")).toHaveValue("W22");
-    // });
   });
 });

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -196,7 +196,42 @@ describe("PersonalScheduleForm tests", () => {
     ).toBeInTheDocument();
   });
 
-  test("Form has initialPersonalSchedule content", async () => {
+  test("Form has initialPersonalSchedule content with Spring quarter", async () => {
+    const queryClient = new QueryClient();
+    const content = {
+      id: 17,
+      user: {
+        id: 1,
+        email: "phtcon@ucsb.edu",
+        googleSub: "115856948234298493496",
+        pictureUrl:
+          "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+        fullName: "Phill Conrad",
+        givenName: "Phill",
+        familyName: "Conrad",
+        emailVerified: true,
+        locale: "en",
+        hostedDomain: "ucsb.edu",
+        admin: true,
+      },
+      description: "My Plan for Spring",
+      quarter: "20222",
+      name: "Spring Courses",
+    };
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <PersonalScheduleForm initialPersonalSchedule={content} />
+        </Router>
+      </QueryClientProvider>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("PersonalScheduleForm-quarter"),
+      ).toHaveValue("S22");
+    });
+  });
+  test("Form has initialPersonalSchedule content with Fall quarter", async () => {
     const queryClient = new QueryClient();
     const content = {
       id: 17,
@@ -215,7 +250,7 @@ describe("PersonalScheduleForm tests", () => {
         admin: true,
       },
       description: "My Plan for Fall",
-      quarter: "20222",
+      quarter: "20224",
       name: "Fall Courses",
     };
     render(
@@ -227,8 +262,43 @@ describe("PersonalScheduleForm tests", () => {
     );
     await waitFor(() => {
       expect(
-        document.querySelector("#PersonalScheduleForm-quarter"),
-      ).toHaveValue("20222");
+        screen.getByTestId("PersonalScheduleForm-quarter"),
+      ).toHaveValue("F22");
+    });
+  });
+  test("Form has initialPersonalSchedule content with M quarter", async () => {
+    const queryClient = new QueryClient();
+    const content = {
+      id: 17,
+      user: {
+        id: 1,
+        email: "phtcon@ucsb.edu",
+        googleSub: "115856948234298493496",
+        pictureUrl:
+          "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+        fullName: "Phill Conrad",
+        givenName: "Phill",
+        familyName: "Conrad",
+        emailVerified: true,
+        locale: "en",
+        hostedDomain: "ucsb.edu",
+        admin: true,
+      },
+      description: "My Plan for M",
+      quarter: "20223",
+      name: "M Courses",
+    };
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <PersonalScheduleForm initialPersonalSchedule={content} />
+        </Router>
+      </QueryClientProvider>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("PersonalScheduleForm-quarter"),
+      ).toHaveValue("M22");
     });
   });
 });

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -195,4 +195,42 @@ describe("PersonalScheduleForm tests", () => {
       await screen.findByText("Max length 15 characters"),
     ).toBeInTheDocument();
   });
+
+  test("Form has initialPersonalSchedule content", async () => {
+    const queryClient = new QueryClient();
+    const content = {
+      id: 17,
+      user: {
+        id: 1,
+        email: "phtcon@ucsb.edu",
+        googleSub: "115856948234298493496",
+        pictureUrl:
+          "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+        fullName: "Phill Conrad",
+        givenName: "Phill",
+        familyName: "Conrad",
+        emailVerified: true,
+        locale: "en",
+        hostedDomain: "ucsb.edu",
+        admin: true,
+      },
+      description: "My Plan for Fall",
+      quarter: "20222",
+      name: "Fall Courses",
+    }
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <PersonalScheduleForm initialPersonalSchedule={content} />
+        </Router>
+      </QueryClientProvider>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector("#PersonalScheduleForm-quarter")).toHaveValue("20222");
+    });
+    console.log("HERE ", document.querySelector("#PersonalScheduleForm-quarter"));
+    // await waitFor(() => {
+    //   expect(screen.getByText("#PersonalScheduleForm-quarter")).toHaveValue("W22");
+    // });
+  });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -1,12 +1,8 @@
-import {
-  fireEvent,
-  render,
-  waitFor,
-  screen,
-} from "@testing-library/react";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
+
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -14,206 +10,226 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import mockConsole from "jest-mock-console";
 
+
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
-  const originalModule = jest.requireActual("react-toastify");
-  return {
-    __esModule: true,
-    ...originalModule,
-    toast: (x) => mockToast(x),
-  };
+ const originalModule = jest.requireActual("react-toastify");
+ return {
+   __esModule: true,
+   ...originalModule,
+   toast: (x) => mockToast(x),
+ };
 });
+
 
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => {
-  const originalModule = jest.requireActual("react-router-dom");
-  return {
-    __esModule: true,
-    ...originalModule,
-    useParams: () => ({
-      id: 17,
-    }),
-    Navigate: (x) => {
-      mockNavigate(x);
-      return null;
-    },
-  };
+ const originalModule = jest.requireActual("react-router-dom");
+ return {
+   __esModule: true,
+   ...originalModule,
+   useParams: () => ({
+     id: 17,
+   }),
+   Navigate: (x) => {
+     mockNavigate(x);
+     return null;
+   },
+ };
 });
 
+
 describe("PersonalSchedulesEditPage tests", () => {
-  describe("when the backend doesn't return data", () => {
-    const axiosMock = new AxiosMockAdapter(axios);
+ describe("when the backend doesn't return data", () => {
+   const axiosMock = new AxiosMockAdapter(axios);
 
-    beforeEach(() => {
-      axiosMock.reset();
-      axiosMock.resetHistory();
-      axiosMock
-        .onGet("/api/currentUser")
-        .reply(200, apiCurrentUserFixtures.userOnly);
-      axiosMock
-        .onGet("/api/systemInfo")
-        .reply(200, systemInfoFixtures.showingNeither);
-      axiosMock
-        .onGet("/api/personalschedules", { params: { id: 17 } })
-        .timeout();
-    });
 
-    const queryClient = new QueryClient();
-    test("renders header but table is not present", async () => {
-      const restoreConsole = mockConsole();
+   beforeEach(() => {
+     axiosMock.reset();
+     axiosMock.resetHistory();
+     axiosMock
+       .onGet("/api/currentUser")
+       .reply(200, apiCurrentUserFixtures.userOnly);
+     axiosMock
+       .onGet("/api/systemInfo")
+       .reply(200, systemInfoFixtures.showingNeither);
+     axiosMock
+       .onGet("/api/personalschedules", { params: { id: 17 } })
+       .timeout();
+   });
 
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <PersonalSchedulesEditPage />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-      await screen.findByText("Edit Personal Schedule");
-      expect(
-        screen.queryByTestId("PersonalScheduleForm-name"),
-      ).not.toBeInTheDocument();
-      restoreConsole();
-    });
-  });
 
-  describe("tests where backend is working normally", () => {
-    const axiosMock = new AxiosMockAdapter(axios);
+   const queryClient = new QueryClient();
+   test("renders header but table is not present", async () => {
+     const restoreConsole = mockConsole();
 
-    beforeEach(() => {
-      axiosMock.reset();
-      axiosMock.resetHistory();
-      axiosMock
-        .onGet("/api/currentUser")
-        .reply(200, apiCurrentUserFixtures.userOnly);
-      axiosMock
-        .onGet("/api/systemInfo")
-        .reply(200, systemInfoFixtures.showingNeither);
-      axiosMock
-        .onGet("/api/personalschedules", { params: { id: 17 } })
-        .reply(200, {
-          id: 17,
-          user: {
-            id: 1,
-            email: "phtcon@ucsb.edu",
-            googleSub: "115856948234298493496",
-            pictureUrl:
-              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-            fullName: "Phill Conrad",
-            givenName: "Phill",
-            familyName: "Conrad",
-            emailVerified: true,
-            locale: "en",
-            hostedDomain: "ucsb.edu",
-            admin: true,
-          },
-          description: "My Winter Courses",
-          quarter: "20221",
-          name: "CS156",
-        });
-      axiosMock.onPut("/api/personalschedules").reply(200, {
-        id: 17,
-        user: {
-          id: 1,
-          email: "phtcon@ucsb.edu",
-          googleSub: "115856948234298493496",
-          pictureUrl:
-            "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-          fullName: "Phill Conrad",
-          givenName: "Phill",
-          familyName: "Conrad",
-          emailVerified: true,
-          locale: "en",
-          hostedDomain: "ucsb.edu",
-          admin: true,
-        },
-        description: "My Plan for Fall",
-        quarter: "20222",
-        name: "Fall Courses",
-      });
-    });
 
-    const queryClient = new QueryClient();
+     render(
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
+     await screen.findByText("Edit Personal Schedule");
+     expect(
+       screen.queryByTestId("PersonalScheduleForm-name"),
+     ).not.toBeInTheDocument();
+     restoreConsole();
+   });
+ });
 
-    test("renders without crashing", () => {
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <PersonalSchedulesEditPage />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-    });
 
-    test("Is populated with the data provided", async () => {
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <PersonalSchedulesEditPage />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
+ describe("tests where backend is working normally", () => {
+   const axiosMock = new AxiosMockAdapter(axios);
 
-      await screen.findByTestId("PersonalScheduleForm-id");
 
-      const idField = screen.getByTestId("PersonalScheduleForm-id");
-      const nameField = screen.getByTestId("PersonalScheduleForm-name");
-      const descriptionField = screen.getByTestId(
-        "PersonalScheduleForm-description",
-      );
-      const quarterField = document.querySelector(
-        "#PersonalScheduleForm-quarter",
-      );
-      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+   beforeEach(() => {
+     axiosMock.reset();
+     axiosMock.resetHistory();
+     axiosMock
+       .onGet("/api/currentUser")
+       .reply(200, apiCurrentUserFixtures.userOnly);
+     axiosMock
+       .onGet("/api/systemInfo")
+       .reply(200, systemInfoFixtures.showingNeither);
+     axiosMock
+       .onGet("/api/personalschedules", { params: { id: 17 } })
+       .reply(200, {
+         id: 17,
+         user: {
+           id: 1,
+           email: "phtcon@ucsb.edu",
+           googleSub: "115856948234298493496",
+           pictureUrl:
+             "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+           fullName: "Phill Conrad",
+           givenName: "Phill",
+           familyName: "Conrad",
+           emailVerified: true,
+           locale: "en",
+           hostedDomain: "ucsb.edu",
+           admin: true,
+         },
+         description: "My Winter Courses",
+         quarter: "20221",
+         name: "CS156",
+       });
+     axiosMock.onPut("/api/personalschedules").reply(200, {
+       id: 17,
+       user: {
+         id: 1,
+         email: "phtcon@ucsb.edu",
+         googleSub: "115856948234298493496",
+         pictureUrl:
+           "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+         fullName: "Phill Conrad",
+         givenName: "Phill",
+         familyName: "Conrad",
+         emailVerified: true,
+         locale: "en",
+         hostedDomain: "ucsb.edu",
+         admin: true,
+       },
+       description: "My Plan for Fall",
+       quarter: "20222",
+       name: "Fall Courses",
+     });
+   });
 
-      expect(idField).toBeInTheDocument();
-      expect(idField).toHaveValue("17");
-      expect(nameField).toBeInTheDocument();
-      expect(nameField).toHaveValue("CS156");
-      expect(descriptionField).toBeInTheDocument();
-      expect(descriptionField).toHaveValue("My Winter Courses");
-      expect(quarterField).toBeInTheDocument();
 
-      expect(submitButton).toHaveTextContent("Update");
+   const queryClient = new QueryClient();
 
-      fireEvent.change(nameField, { target: { value: "Fall Courses" } });
-      fireEvent.change(descriptionField, {
-        target: { value: "My Plan for Fall" },
-      });
-      fireEvent.change(quarterField, { target: { value: "20222" } });
 
-      fireEvent.click(submitButton);
+   test("renders without crashing", () => {
+     render(
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
+   });
 
-      await waitFor(() => expect(mockToast).toBeCalled());
-      expect(mockToast).toBeCalledWith(
-        "PersonalSchedule Updated - id: 17 name: Fall Courses",
-      );
 
-      expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
+   test("Is populated with the data provided", async () => {
+     render(
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
 
-      expect(axiosMock.history.put.length).toBe(1); // times called
-      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
-      expect(axiosMock.history.put[0].data).toBe(
-        JSON.stringify({
-          user: {
-            id: 1,
-            email: "phtcon@ucsb.edu",
-            googleSub: "115856948234298493496",
-            pictureUrl:
-              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-            fullName: "Phill Conrad",
-            givenName: "Phill",
-            familyName: "Conrad",
-            emailVerified: true,
-            locale: "en",
-            hostedDomain: "ucsb.edu",
-            admin: true,
-          },
-          name: "Fall Courses",
-          description: "My Plan for Fall",
-          quarter: "20222",
-        }),
-      ); // posted object
-    });
-  });
+
+     await screen.findByTestId("PersonalScheduleForm-id");
+
+
+     const idField = screen.getByTestId("PersonalScheduleForm-id");
+     const nameField = screen.getByTestId("PersonalScheduleForm-name");
+     const descriptionField = screen.getByTestId(
+       "PersonalScheduleForm-description",
+     );
+     const quarterField = document.querySelector(
+       "#PersonalScheduleForm-quarter",
+     );
+     const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+
+     expect(idField).toBeInTheDocument();
+     expect(idField).toHaveValue("17");
+     expect(nameField).toBeInTheDocument();
+     expect(nameField).toHaveValue("CS156");
+     expect(descriptionField).toBeInTheDocument();
+     expect(descriptionField).toHaveValue("My Winter Courses");
+     expect(quarterField).toBeInTheDocument();
+
+
+     expect(submitButton).toHaveTextContent("Update");
+
+
+     fireEvent.change(nameField, { target: { value: "Fall Courses" } });
+     fireEvent.change(descriptionField, {
+       target: { value: "My Plan for Fall" },
+     });
+     fireEvent.change(quarterField, { target: { value: "20222" } });
+
+
+     fireEvent.click(submitButton);
+
+
+     await waitFor(() => expect(mockToast).toBeCalled());
+     expect(mockToast).toBeCalledWith(
+       "PersonalSchedule Updated - id: 17 name: Fall Courses",
+     );
+
+
+     expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
+
+
+     expect(axiosMock.history.put.length).toBe(1); // times called
+     expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+     expect(axiosMock.history.put[0].data).toBe(
+       JSON.stringify({
+         user: {
+           id: 1,
+           email: "phtcon@ucsb.edu",
+           googleSub: "115856948234298493496",
+           pictureUrl:
+             "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+           fullName: "Phill Conrad",
+           givenName: "Phill",
+           familyName: "Conrad",
+           emailVerified: true,
+           locale: "en",
+           hostedDomain: "ucsb.edu",
+           admin: true,
+         },
+         name: "Fall Courses",
+         description: "My Plan for Fall",
+         quarter: "20222",
+       }),
+     ); // posted object
+   });
+ });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -1,5 +1,9 @@
-import { fireEvent, render, waitFor, screen, getByTestId, getByLabelText } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import {
+  fireEvent,
+  render,
+  waitFor,
+  screen,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
@@ -11,69 +15,83 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import mockConsole from "jest-mock-console";
 
 const mockToast = jest.fn();
-jest.mock('react-toastify', () => {
-    const originalModule = jest.requireActual('react-toastify');
-    return {
-        __esModule: true,
-        ...originalModule,
-        toast: (x) => mockToast(x)
-    };
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
 });
 
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => {
-    const originalModule = jest.requireActual('react-router-dom');
-    return {
-        __esModule: true,
-        ...originalModule,
-        useParams: () => ({
-            id: 17
-        }),
-        Navigate: (x) => { mockNavigate(x); return null; }
-    };
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
 });
 
 describe("PersonalSchedulesEditPage tests", () => {
   describe("when the backend doesn't return data", () => {
-
     const axiosMock = new AxiosMockAdapter(axios);
 
     beforeEach(() => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        axiosMock.onGet("/api/personalschedules", { params: { id: 17 } }).timeout();
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/personalschedules", { params: { id: 17 } })
+        .timeout();
     });
 
     const queryClient = new QueryClient();
     test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
 
-        const restoreConsole = mockConsole();
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PersonalSchedulesEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-        await screen.findByText("Edit Personal Schedule");
-        expect(screen.queryByTestId("PersonalScheduleForm-name")).not.toBeInTheDocument();
-        restoreConsole();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Personal Schedule");
+      expect(
+        screen.queryByTestId("PersonalScheduleForm-name"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
     });
-});
+  });
 
-describe("tests where backend is working normally", () => {
-
+  describe("tests where backend is working normally", () => {
     const axiosMock = new AxiosMockAdapter(axios);
 
     beforeEach(() => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        axiosMock.onGet("/api/personalschedules", { params: { id: 17 } }).reply(200, {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/personalschedules", { params: { id: 17 } })
+        .reply(200, {
           id: 17,
           user: {
             id: 1,
@@ -93,82 +111,90 @@ describe("tests where backend is working normally", () => {
           quarter: "20221",
           name: "CS156",
         });
-        axiosMock.onPut('/api/personalschedules').reply(200, {
-          id: 17,
-          user: {
-            id: 1,
-            email: "phtcon@ucsb.edu",
-            googleSub: "115856948234298493496",
-            pictureUrl:
-              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-            fullName: "Phill Conrad",
-            givenName: "Phill",
-            familyName: "Conrad",
-            emailVerified: true,
-            locale: "en",
-            hostedDomain: "ucsb.edu",
-            admin: true,
-          },
-          description: "My Plan for Fall",
-          quarter: "20222",
-          name: "Fall Courses",
-        });
+      axiosMock.onPut("/api/personalschedules").reply(200, {
+        id: 17,
+        user: {
+          id: 1,
+          email: "phtcon@ucsb.edu",
+          googleSub: "115856948234298493496",
+          pictureUrl:
+            "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+          fullName: "Phill Conrad",
+          givenName: "Phill",
+          familyName: "Conrad",
+          emailVerified: true,
+          locale: "en",
+          hostedDomain: "ucsb.edu",
+          admin: true,
+        },
+        description: "My Plan for Fall",
+        quarter: "20222",
+        name: "Fall Courses",
+      });
     });
 
     const queryClient = new QueryClient();
 
     test("renders without crashing", () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PersonalSchedulesEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
     });
 
     test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
 
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PersonalSchedulesEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+      await screen.findByTestId("PersonalScheduleForm-id");
 
-        await screen.findByTestId("PersonalScheduleForm-id");
+      const idField = screen.getByTestId("PersonalScheduleForm-id");
+      const nameField = screen.getByTestId("PersonalScheduleForm-name");
+      const descriptionField = screen.getByTestId(
+        "PersonalScheduleForm-description",
+      );
+      const quarterField = document.querySelector(
+        "#PersonalScheduleForm-quarter",
+      );
+      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
-        const idField = screen.getByTestId("PersonalScheduleForm-id");
-        const nameField = screen.getByTestId("PersonalScheduleForm-name");
-        const descriptionField = screen.getByTestId("PersonalScheduleForm-description");
-        const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
-        const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(nameField).toBeInTheDocument();
+      expect(nameField).toHaveValue("CS156");
+      expect(descriptionField).toBeInTheDocument();
+      expect(descriptionField).toHaveValue("My Winter Courses");
+      expect(quarterField).toBeInTheDocument();
 
-        expect(idField).toBeInTheDocument();
-        expect(idField).toHaveValue("17");
-        expect(nameField).toBeInTheDocument();
-        expect(nameField).toHaveValue("CS156");
-        expect(descriptionField).toBeInTheDocument();
-        expect(descriptionField).toHaveValue("My Winter Courses");
-        expect(quarterField).toBeInTheDocument();
+      expect(submitButton).toHaveTextContent("Update");
 
-        expect(submitButton).toHaveTextContent("Update");
-        
-        fireEvent.change(nameField, { target: { value: 'Fall Courses' } });
-        fireEvent.change(descriptionField, { target: { value: 'My Plan for Fall' } });
-        fireEvent.change(quarterField, { target: { value: '20222' } });
+      fireEvent.change(nameField, { target: { value: "Fall Courses" } });
+      fireEvent.change(descriptionField, {
+        target: { value: "My Plan for Fall" },
+      });
+      fireEvent.change(quarterField, { target: { value: "20222" } });
 
-        fireEvent.click(submitButton);
+      fireEvent.click(submitButton);
 
-        await waitFor(() => expect(mockToast).toBeCalled());
-        expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 17 name: Fall Courses");
-        
-        expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "PersonalSchedule Updated - id: 17 name: Fall Courses",
+      );
 
-        expect(axiosMock.history.put.length).toBe(1); // times called
-        expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
-        expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+      expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
           user: {
             id: 1,
             email: "phtcon@ucsb.edu",
@@ -186,8 +212,8 @@ describe("tests where backend is working normally", () => {
           name: "Fall Courses",
           description: "My Plan for Fall",
           quarter: "20222",
-        })); // posted object
+        }),
+      ); // posted object
     });
-   
-});
+  });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -3,233 +3,212 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
 
-
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import mockConsole from "jest-mock-console";
 
-
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
- const originalModule = jest.requireActual("react-toastify");
- return {
-   __esModule: true,
-   ...originalModule,
-   toast: (x) => mockToast(x),
- };
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
 });
-
 
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => {
- const originalModule = jest.requireActual("react-router-dom");
- return {
-   __esModule: true,
-   ...originalModule,
-   useParams: () => ({
-     id: 17,
-   }),
-   Navigate: (x) => {
-     mockNavigate(x);
-     return null;
-   },
- };
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
 });
 
-
 describe("PersonalSchedulesEditPage tests", () => {
- describe("when the backend doesn't return data", () => {
-   const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/personalschedules", { params: { id: 17 } })
+        .timeout();
+    });
 
-   beforeEach(() => {
-     axiosMock.reset();
-     axiosMock.resetHistory();
-     axiosMock
-       .onGet("/api/currentUser")
-       .reply(200, apiCurrentUserFixtures.userOnly);
-     axiosMock
-       .onGet("/api/systemInfo")
-       .reply(200, systemInfoFixtures.showingNeither);
-     axiosMock
-       .onGet("/api/personalschedules", { params: { id: 17 } })
-       .timeout();
-   });
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
 
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Personal Schedule");
+      expect(
+        screen.queryByTestId("PersonalScheduleForm-name"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
 
-   const queryClient = new QueryClient();
-   test("renders header but table is not present", async () => {
-     const restoreConsole = mockConsole();
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/personalschedules", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          description: "My Winter Courses",
+          quarter: "20221",
+          name: "CS156",
+        });
+      axiosMock.onPut("/api/personalschedules").reply(200, {
+        id: 17,
+        user: {
+          id: 1,
+          email: "phtcon@ucsb.edu",
+          googleSub: "115856948234298493496",
+          pictureUrl:
+            "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+          fullName: "Phill Conrad",
+          givenName: "Phill",
+          familyName: "Conrad",
+          emailVerified: true,
+          locale: "en",
+          hostedDomain: "ucsb.edu",
+          admin: true,
+        },
+        description: "My Plan for Fall",
+        quarter: "20222",
+        name: "Fall Courses",
+      });
+    });
 
-     render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
-     await screen.findByText("Edit Personal Schedule");
-     expect(
-       screen.queryByTestId("PersonalScheduleForm-name"),
-     ).not.toBeInTheDocument();
-     restoreConsole();
-   });
- });
+    const queryClient = new QueryClient();
 
+    test("renders without crashing", () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
 
- describe("tests where backend is working normally", () => {
-   const axiosMock = new AxiosMockAdapter(axios);
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
 
+      await screen.findByTestId("PersonalScheduleForm-id");
 
-   beforeEach(() => {
-     axiosMock.reset();
-     axiosMock.resetHistory();
-     axiosMock
-       .onGet("/api/currentUser")
-       .reply(200, apiCurrentUserFixtures.userOnly);
-     axiosMock
-       .onGet("/api/systemInfo")
-       .reply(200, systemInfoFixtures.showingNeither);
-     axiosMock
-       .onGet("/api/personalschedules", { params: { id: 17 } })
-       .reply(200, {
-         id: 17,
-         user: {
-           id: 1,
-           email: "phtcon@ucsb.edu",
-           googleSub: "115856948234298493496",
-           pictureUrl:
-             "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-           fullName: "Phill Conrad",
-           givenName: "Phill",
-           familyName: "Conrad",
-           emailVerified: true,
-           locale: "en",
-           hostedDomain: "ucsb.edu",
-           admin: true,
-         },
-         description: "My Winter Courses",
-         quarter: "20221",
-         name: "CS156",
-       });
-     axiosMock.onPut("/api/personalschedules").reply(200, {
-       id: 17,
-       user: {
-         id: 1,
-         email: "phtcon@ucsb.edu",
-         googleSub: "115856948234298493496",
-         pictureUrl:
-           "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-         fullName: "Phill Conrad",
-         givenName: "Phill",
-         familyName: "Conrad",
-         emailVerified: true,
-         locale: "en",
-         hostedDomain: "ucsb.edu",
-         admin: true,
-       },
-       description: "My Plan for Fall",
-       quarter: "20222",
-       name: "Fall Courses",
-     });
-   });
+      const idField = screen.getByTestId("PersonalScheduleForm-id");
+      const nameField = screen.getByTestId("PersonalScheduleForm-name");
+      const descriptionField = screen.getByTestId(
+        "PersonalScheduleForm-description",
+      );
+      const quarterField = document.querySelector(
+        "#PersonalScheduleForm-quarter",
+      );
+      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(nameField).toBeInTheDocument();
+      expect(nameField).toHaveValue("CS156");
+      expect(descriptionField).toBeInTheDocument();
+      expect(descriptionField).toHaveValue("My Winter Courses");
+      expect(quarterField).toBeInTheDocument();
 
-   const queryClient = new QueryClient();
+      expect(submitButton).toHaveTextContent("Update");
 
+      fireEvent.change(nameField, { target: { value: "Fall Courses" } });
+      fireEvent.change(descriptionField, {
+        target: { value: "My Plan for Fall" },
+      });
+      fireEvent.change(quarterField, { target: { value: "20222" } });
 
-   test("renders without crashing", () => {
-     render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
-   });
+      fireEvent.click(submitButton);
 
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "PersonalSchedule Updated - id: 17 name: Fall Courses",
+      );
 
-   test("Is populated with the data provided", async () => {
-     render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
+      expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
 
-
-     await screen.findByTestId("PersonalScheduleForm-id");
-
-
-     const idField = screen.getByTestId("PersonalScheduleForm-id");
-     const nameField = screen.getByTestId("PersonalScheduleForm-name");
-     const descriptionField = screen.getByTestId(
-       "PersonalScheduleForm-description",
-     );
-     const quarterField = document.querySelector(
-       "#PersonalScheduleForm-quarter",
-     );
-     const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
-
-
-     expect(idField).toBeInTheDocument();
-     expect(idField).toHaveValue("17");
-     expect(nameField).toBeInTheDocument();
-     expect(nameField).toHaveValue("CS156");
-     expect(descriptionField).toBeInTheDocument();
-     expect(descriptionField).toHaveValue("My Winter Courses");
-     expect(quarterField).toBeInTheDocument();
-
-
-     expect(submitButton).toHaveTextContent("Update");
-
-
-     fireEvent.change(nameField, { target: { value: "Fall Courses" } });
-     fireEvent.change(descriptionField, {
-       target: { value: "My Plan for Fall" },
-     });
-     fireEvent.change(quarterField, { target: { value: "20222" } });
-
-
-     fireEvent.click(submitButton);
-
-
-     await waitFor(() => expect(mockToast).toBeCalled());
-     expect(mockToast).toBeCalledWith(
-       "PersonalSchedule Updated - id: 17 name: Fall Courses",
-     );
-
-
-     expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
-
-
-     expect(axiosMock.history.put.length).toBe(1); // times called
-     expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
-     expect(axiosMock.history.put[0].data).toBe(
-       JSON.stringify({
-         user: {
-           id: 1,
-           email: "phtcon@ucsb.edu",
-           googleSub: "115856948234298493496",
-           pictureUrl:
-             "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-           fullName: "Phill Conrad",
-           givenName: "Phill",
-           familyName: "Conrad",
-           emailVerified: true,
-           locale: "en",
-           hostedDomain: "ucsb.edu",
-           admin: true,
-         },
-         name: "Fall Courses",
-         description: "My Plan for Fall",
-         quarter: "20222",
-       }),
-     ); // posted object
-   });
- });
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          name: "Fall Courses",
+          description: "My Plan for Fall",
+          quarter: "20222",
+        }),
+      ); // posted object
+    });
+  });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -11,299 +11,279 @@ import mockConsole from "jest-mock-console";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
- const originalModule = jest.requireActual("react-toastify");
- return {
-   __esModule: true,
-   ...originalModule,
-   toast: (x) => mockToast(x),
- };
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
 });
 
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => {
- const originalModule = jest.requireActual("react-router-dom");
- return {
-   __esModule: true,
-   ...originalModule,
-   useParams: () => ({
-     id: 17,
-   }),
-   Navigate: (x) => {
-     mockNavigate(x);
-     return null;
-   },
- };
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
 });
 
-
 describe("PersonalSchedulesEditPage tests", () => {
- describe("when the backend doesn't return data", () => {
-   const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/personalschedules", { params: { id: 17 } })
+        .timeout();
+    });
 
-   beforeEach(() => {
-     axiosMock.reset();
-     axiosMock.resetHistory();
-     axiosMock
-       .onGet("/api/currentUser")
-       .reply(200, apiCurrentUserFixtures.userOnly);
-     axiosMock
-       .onGet("/api/systemInfo")
-       .reply(200, systemInfoFixtures.showingNeither);
-     axiosMock
-       .onGet("/api/personalschedules", { params: { id: 17 } })
-       .timeout();
-   });
-
-
-   const queryClient = new QueryClient();
-   test("renders header but table is not present", async () => {
-     const restoreConsole = mockConsole();
-
-
-     render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
-     await screen.findByText("Edit Personal Schedule");
-     expect(
-       screen.queryByTestId("PersonalScheduleForm-name"),
-     ).not.toBeInTheDocument();
-     restoreConsole();
-   });
- });
-
-
- describe("tests where backend is working normally", () => {
-   const axiosMock = new AxiosMockAdapter(axios);
-
-
-   beforeEach(() => {
-     axiosMock.reset();
-     axiosMock.resetHistory();
-     axiosMock
-       .onGet("/api/currentUser")
-       .reply(200, apiCurrentUserFixtures.userOnly);
-     axiosMock
-       .onGet("/api/systemInfo")
-       .reply(200, systemInfoFixtures.showingNeither);
-     axiosMock
-       .onGet("/api/personalschedules", { params: { id: 17 } })
-       .reply(200, {
-         id: 17,
-         user: {
-           id: 1,
-           email: "phtcon@ucsb.edu",
-           googleSub: "115856948234298493496",
-           pictureUrl:
-             "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-           fullName: "Phill Conrad",
-           givenName: "Phill",
-           familyName: "Conrad",
-           emailVerified: true,
-           locale: "en",
-           hostedDomain: "ucsb.edu",
-           admin: true,
-         },
-         description: "My Winter Courses",
-         quarter: "20221",
-         name: "CS156",
-       });
-     axiosMock.onPut("/api/personalschedules").reply(200, {
-       id: 17,
-       user: {
-         id: 1,
-         email: "phtcon@ucsb.edu",
-         googleSub: "115856948234298493496",
-         pictureUrl:
-           "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-         fullName: "Phill Conrad",
-         givenName: "Phill",
-         familyName: "Conrad",
-         emailVerified: true,
-         locale: "en",
-         hostedDomain: "ucsb.edu",
-         admin: true,
-       },
-       description: "My Plan for Fall",
-       quarter: "20222",
-       name: "Fall Courses",
-     });
-   });
-
-
-   const queryClient = new QueryClient();
-
-
-   test("renders without crashing", () => {
-     render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
-   });
-
-
-   test("Is populated with the data provided", async () => {
-     render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
-
-
-     await screen.findByTestId("PersonalScheduleForm-id");
-
-
-     const idField = screen.getByTestId("PersonalScheduleForm-id");
-     const nameField = screen.getByTestId("PersonalScheduleForm-name");
-     const descriptionField = screen.getByTestId(
-       "PersonalScheduleForm-description",
-     );
-     const quarterField = document.querySelector(
-       "#PersonalScheduleForm-quarter",
-     );
-     const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
-
-
-     expect(idField).toBeInTheDocument();
-     expect(idField).toHaveValue("17");
-     expect(nameField).toBeInTheDocument();
-     expect(nameField).toHaveValue("CS156");
-     expect(descriptionField).toBeInTheDocument();
-     expect(descriptionField).toHaveValue("My Winter Courses");
-     expect(quarterField).toBeInTheDocument();
-
-
-     expect(submitButton).toHaveTextContent("Update");
-
-
-     fireEvent.change(nameField, { target: { value: "Fall Courses" } });
-     fireEvent.change(descriptionField, {
-       target: { value: "My Plan for Fall" },
-     });
-     fireEvent.change(quarterField, { target: { value: "20222" } });
-
-
-     fireEvent.click(submitButton);
-
-
-     await waitFor(() => expect(mockToast).toBeCalled());
-     expect(mockToast).toBeCalledWith(
-       "PersonalSchedule Updated - id: 17 name: Fall Courses",
-     );
-
-
-     expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
-
-
-     expect(axiosMock.history.put.length).toBe(1); // times called
-     expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
-     expect(axiosMock.history.put[0].data).toBe(
-       JSON.stringify({
-         user: {
-           id: 1,
-           email: "phtcon@ucsb.edu",
-           googleSub: "115856948234298493496",
-           pictureUrl:
-             "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-           fullName: "Phill Conrad",
-           givenName: "Phill",
-           familyName: "Conrad",
-           emailVerified: true,
-           locale: "en",
-           hostedDomain: "ucsb.edu",
-           admin: true,
-         },
-         name: "Fall Courses",
-         description: "My Plan for Fall",
-         quarter: "20222",
-       }),
-     ); // posted object
-   });
-   test("renders without crashing for regular user", () => {
-     const queryClient = new QueryClient();
-     axiosMock.onGet("/api/courses/user/all").reply(200, []);
-      render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
-   });
-   test("renders without crashing for admin user", () => {
-     const queryClient = new QueryClient();
-     axiosMock.onGet("/api/courses/admin/all").reply(200, []);
-      render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
-   });
-   const testId = "CourseTable";
-   test("renders two courses without crashing for regular user", async () => {
-     const queryClient = new QueryClient();
-     axiosMock
-       .onGet("/api/courses/user/psid/all?psId=17")
-       .reply(200, coursesFixtures.twoCourses);
-      render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
-     // await waitFor(() => {
-     //   expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
-     // });
-
-
-     // console.log(axiosMock.history.get.length)
-     // axiosMock.history.get.forEach((get) => {
-     //   console.log(get.url);
-     // })
-     await waitFor(() => {
-       expect(
-         screen.getByTestId(`${testId}-cell-row-0-col-id`)
-       ).toHaveTextContent("25");
-     });
-     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
-       "26",
-     );
-   });
-  
-   test("doesn't render course with different psid", async () => {
-     const queryClient = new QueryClient();
-     axiosMock
-       .onGet("/api/courses/user/psid/all?psId=13")
-       .reply(200, coursesFixtures.oneCourse);
-
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
 
       render(
-       <QueryClientProvider client={queryClient}>
-         <MemoryRouter>
-           <PersonalSchedulesEditPage />
-         </MemoryRouter>
-       </QueryClientProvider>,
-     );
-     // await waitFor(() => {
-     //   expect(
-     //     screen.getByTestId(`${testId}-cell-row-0-col-id`)
-     //   ).toHaveTextContent("25");
-     // });
-     expect(
-       screen.queryByTestId(`${testId}-cell-row-0-col-id`),
-     ).not.toBeInTheDocument();
-   });
- });
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Personal Schedule");
+      expect(
+        screen.queryByTestId("PersonalScheduleForm-name"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/personalschedules", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          description: "My Winter Courses",
+          quarter: "20221",
+          name: "CS156",
+        });
+      axiosMock.onPut("/api/personalschedules").reply(200, {
+        id: 17,
+        user: {
+          id: 1,
+          email: "phtcon@ucsb.edu",
+          googleSub: "115856948234298493496",
+          pictureUrl:
+            "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+          fullName: "Phill Conrad",
+          givenName: "Phill",
+          familyName: "Conrad",
+          emailVerified: true,
+          locale: "en",
+          hostedDomain: "ucsb.edu",
+          admin: true,
+        },
+        description: "My Plan for Fall",
+        quarter: "20222",
+        name: "Fall Courses",
+      });
+    });
+
+    const queryClient = new QueryClient();
+
+    test("renders without crashing", () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("PersonalScheduleForm-id");
+
+      const idField = screen.getByTestId("PersonalScheduleForm-id");
+      const nameField = screen.getByTestId("PersonalScheduleForm-name");
+      const descriptionField = screen.getByTestId(
+        "PersonalScheduleForm-description",
+      );
+      const quarterField = document.querySelector(
+        "#PersonalScheduleForm-quarter",
+      );
+      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(nameField).toBeInTheDocument();
+      expect(nameField).toHaveValue("CS156");
+      expect(descriptionField).toBeInTheDocument();
+      expect(descriptionField).toHaveValue("My Winter Courses");
+      expect(quarterField).toBeInTheDocument();
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(nameField, { target: { value: "Fall Courses" } });
+      fireEvent.change(descriptionField, {
+        target: { value: "My Plan for Fall" },
+      });
+      fireEvent.change(quarterField, { target: { value: "20222" } });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "PersonalSchedule Updated - id: 17 name: Fall Courses",
+      );
+
+      expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          name: "Fall Courses",
+          description: "My Plan for Fall",
+          quarter: "20222",
+        }),
+      ); // posted object
+    });
+    test("renders without crashing for regular user", () => {
+      const queryClient = new QueryClient();
+      axiosMock.onGet("/api/courses/user/all").reply(200, []);
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+    test("renders without crashing for admin user", () => {
+      const queryClient = new QueryClient();
+      axiosMock.onGet("/api/courses/admin/all").reply(200, []);
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+    const testId = "CourseTable";
+    test("renders two courses without crashing for regular user", async () => {
+      const queryClient = new QueryClient();
+      axiosMock
+        .onGet("/api/courses/user/psid/all?psId=17")
+        .reply(200, coursesFixtures.twoCourses);
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      // await waitFor(() => {
+      //   expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+      // });
+
+      // console.log(axiosMock.history.get.length)
+      // axiosMock.history.get.forEach((get) => {
+      //   console.log(get.url);
+      // })
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(`${testId}-cell-row-0-col-id`),
+        ).toHaveTextContent("25");
+      });
+      expect(
+        screen.getByTestId(`${testId}-cell-row-1-col-id`),
+      ).toHaveTextContent("26");
+    });
+
+    test("doesn't render course with different psid", async () => {
+      const queryClient = new QueryClient();
+      axiosMock
+        .onGet("/api/courses/user/psid/all?psId=13")
+        .reply(200, coursesFixtures.oneCourse);
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      // await waitFor(() => {
+      //   expect(
+      //     screen.getByTestId(`${testId}-cell-row-0-col-id`)
+      //   ).toHaveTextContent("25");
+      // });
+      expect(
+        screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
-
+import { coursesFixtures } from "fixtures/pscourseFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
@@ -11,204 +11,299 @@ import mockConsole from "jest-mock-console";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
-  const originalModule = jest.requireActual("react-toastify");
-  return {
-    __esModule: true,
-    ...originalModule,
-    toast: (x) => mockToast(x),
-  };
+ const originalModule = jest.requireActual("react-toastify");
+ return {
+   __esModule: true,
+   ...originalModule,
+   toast: (x) => mockToast(x),
+ };
 });
 
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => {
-  const originalModule = jest.requireActual("react-router-dom");
-  return {
-    __esModule: true,
-    ...originalModule,
-    useParams: () => ({
-      id: 17,
-    }),
-    Navigate: (x) => {
-      mockNavigate(x);
-      return null;
-    },
-  };
+ const originalModule = jest.requireActual("react-router-dom");
+ return {
+   __esModule: true,
+   ...originalModule,
+   useParams: () => ({
+     id: 17,
+   }),
+   Navigate: (x) => {
+     mockNavigate(x);
+     return null;
+   },
+ };
 });
 
+
 describe("PersonalSchedulesEditPage tests", () => {
-  describe("when the backend doesn't return data", () => {
-    const axiosMock = new AxiosMockAdapter(axios);
+ describe("when the backend doesn't return data", () => {
+   const axiosMock = new AxiosMockAdapter(axios);
 
-    beforeEach(() => {
-      axiosMock.reset();
-      axiosMock.resetHistory();
-      axiosMock
-        .onGet("/api/currentUser")
-        .reply(200, apiCurrentUserFixtures.userOnly);
-      axiosMock
-        .onGet("/api/systemInfo")
-        .reply(200, systemInfoFixtures.showingNeither);
-      axiosMock
-        .onGet("/api/personalschedules", { params: { id: 17 } })
-        .timeout();
-    });
 
-    const queryClient = new QueryClient();
-    test("renders header but table is not present", async () => {
-      const restoreConsole = mockConsole();
+   beforeEach(() => {
+     axiosMock.reset();
+     axiosMock.resetHistory();
+     axiosMock
+       .onGet("/api/currentUser")
+       .reply(200, apiCurrentUserFixtures.userOnly);
+     axiosMock
+       .onGet("/api/systemInfo")
+       .reply(200, systemInfoFixtures.showingNeither);
+     axiosMock
+       .onGet("/api/personalschedules", { params: { id: 17 } })
+       .timeout();
+   });
+
+
+   const queryClient = new QueryClient();
+   test("renders header but table is not present", async () => {
+     const restoreConsole = mockConsole();
+
+
+     render(
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
+     await screen.findByText("Edit Personal Schedule");
+     expect(
+       screen.queryByTestId("PersonalScheduleForm-name"),
+     ).not.toBeInTheDocument();
+     restoreConsole();
+   });
+ });
+
+
+ describe("tests where backend is working normally", () => {
+   const axiosMock = new AxiosMockAdapter(axios);
+
+
+   beforeEach(() => {
+     axiosMock.reset();
+     axiosMock.resetHistory();
+     axiosMock
+       .onGet("/api/currentUser")
+       .reply(200, apiCurrentUserFixtures.userOnly);
+     axiosMock
+       .onGet("/api/systemInfo")
+       .reply(200, systemInfoFixtures.showingNeither);
+     axiosMock
+       .onGet("/api/personalschedules", { params: { id: 17 } })
+       .reply(200, {
+         id: 17,
+         user: {
+           id: 1,
+           email: "phtcon@ucsb.edu",
+           googleSub: "115856948234298493496",
+           pictureUrl:
+             "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+           fullName: "Phill Conrad",
+           givenName: "Phill",
+           familyName: "Conrad",
+           emailVerified: true,
+           locale: "en",
+           hostedDomain: "ucsb.edu",
+           admin: true,
+         },
+         description: "My Winter Courses",
+         quarter: "20221",
+         name: "CS156",
+       });
+     axiosMock.onPut("/api/personalschedules").reply(200, {
+       id: 17,
+       user: {
+         id: 1,
+         email: "phtcon@ucsb.edu",
+         googleSub: "115856948234298493496",
+         pictureUrl:
+           "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+         fullName: "Phill Conrad",
+         givenName: "Phill",
+         familyName: "Conrad",
+         emailVerified: true,
+         locale: "en",
+         hostedDomain: "ucsb.edu",
+         admin: true,
+       },
+       description: "My Plan for Fall",
+       quarter: "20222",
+       name: "Fall Courses",
+     });
+   });
+
+
+   const queryClient = new QueryClient();
+
+
+   test("renders without crashing", () => {
+     render(
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
+   });
+
+
+   test("Is populated with the data provided", async () => {
+     render(
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
+
+
+     await screen.findByTestId("PersonalScheduleForm-id");
+
+
+     const idField = screen.getByTestId("PersonalScheduleForm-id");
+     const nameField = screen.getByTestId("PersonalScheduleForm-name");
+     const descriptionField = screen.getByTestId(
+       "PersonalScheduleForm-description",
+     );
+     const quarterField = document.querySelector(
+       "#PersonalScheduleForm-quarter",
+     );
+     const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+
+     expect(idField).toBeInTheDocument();
+     expect(idField).toHaveValue("17");
+     expect(nameField).toBeInTheDocument();
+     expect(nameField).toHaveValue("CS156");
+     expect(descriptionField).toBeInTheDocument();
+     expect(descriptionField).toHaveValue("My Winter Courses");
+     expect(quarterField).toBeInTheDocument();
+
+
+     expect(submitButton).toHaveTextContent("Update");
+
+
+     fireEvent.change(nameField, { target: { value: "Fall Courses" } });
+     fireEvent.change(descriptionField, {
+       target: { value: "My Plan for Fall" },
+     });
+     fireEvent.change(quarterField, { target: { value: "20222" } });
+
+
+     fireEvent.click(submitButton);
+
+
+     await waitFor(() => expect(mockToast).toBeCalled());
+     expect(mockToast).toBeCalledWith(
+       "PersonalSchedule Updated - id: 17 name: Fall Courses",
+     );
+
+
+     expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
+
+
+     expect(axiosMock.history.put.length).toBe(1); // times called
+     expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+     expect(axiosMock.history.put[0].data).toBe(
+       JSON.stringify({
+         user: {
+           id: 1,
+           email: "phtcon@ucsb.edu",
+           googleSub: "115856948234298493496",
+           pictureUrl:
+             "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+           fullName: "Phill Conrad",
+           givenName: "Phill",
+           familyName: "Conrad",
+           emailVerified: true,
+           locale: "en",
+           hostedDomain: "ucsb.edu",
+           admin: true,
+         },
+         name: "Fall Courses",
+         description: "My Plan for Fall",
+         quarter: "20222",
+       }),
+     ); // posted object
+   });
+   test("renders without crashing for regular user", () => {
+     const queryClient = new QueryClient();
+     axiosMock.onGet("/api/courses/user/all").reply(200, []);
+      render(
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
+   });
+   test("renders without crashing for admin user", () => {
+     const queryClient = new QueryClient();
+     axiosMock.onGet("/api/courses/admin/all").reply(200, []);
+      render(
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
+   });
+   const testId = "CourseTable";
+   test("renders two courses without crashing for regular user", async () => {
+     const queryClient = new QueryClient();
+     axiosMock
+       .onGet("/api/courses/user/psid/all?psId=17")
+       .reply(200, coursesFixtures.twoCourses);
+      render(
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
+     // await waitFor(() => {
+     //   expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+     // });
+
+
+     // console.log(axiosMock.history.get.length)
+     // axiosMock.history.get.forEach((get) => {
+     //   console.log(get.url);
+     // })
+     await waitFor(() => {
+       expect(
+         screen.getByTestId(`${testId}-cell-row-0-col-id`)
+       ).toHaveTextContent("25");
+     });
+     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+       "26",
+     );
+   });
+  
+   test("doesn't render course with different psid", async () => {
+     const queryClient = new QueryClient();
+     axiosMock
+       .onGet("/api/courses/user/psid/all?psId=13")
+       .reply(200, coursesFixtures.oneCourse);
+
 
       render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <PersonalSchedulesEditPage />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-      await screen.findByText("Edit Personal Schedule");
-      expect(
-        screen.queryByTestId("PersonalScheduleForm-name"),
-      ).not.toBeInTheDocument();
-      restoreConsole();
-    });
-  });
-
-  describe("tests where backend is working normally", () => {
-    const axiosMock = new AxiosMockAdapter(axios);
-
-    beforeEach(() => {
-      axiosMock.reset();
-      axiosMock.resetHistory();
-      axiosMock
-        .onGet("/api/currentUser")
-        .reply(200, apiCurrentUserFixtures.userOnly);
-      axiosMock
-        .onGet("/api/systemInfo")
-        .reply(200, systemInfoFixtures.showingNeither);
-      axiosMock
-        .onGet("/api/personalschedules", { params: { id: 17 } })
-        .reply(200, {
-          id: 17,
-          user: {
-            id: 1,
-            email: "phtcon@ucsb.edu",
-            googleSub: "115856948234298493496",
-            pictureUrl:
-              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-            fullName: "Phill Conrad",
-            givenName: "Phill",
-            familyName: "Conrad",
-            emailVerified: true,
-            locale: "en",
-            hostedDomain: "ucsb.edu",
-            admin: true,
-          },
-          description: "My Winter Courses",
-          quarter: "20221",
-          name: "CS156",
-        });
-      axiosMock.onPut("/api/personalschedules").reply(200, {
-        id: 17,
-        user: {
-          id: 1,
-          email: "phtcon@ucsb.edu",
-          googleSub: "115856948234298493496",
-          pictureUrl:
-            "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-          fullName: "Phill Conrad",
-          givenName: "Phill",
-          familyName: "Conrad",
-          emailVerified: true,
-          locale: "en",
-          hostedDomain: "ucsb.edu",
-          admin: true,
-        },
-        description: "My Plan for Fall",
-        quarter: "20222",
-        name: "Fall Courses",
-      });
-    });
-
-    const queryClient = new QueryClient();
-
-    test("renders without crashing", () => {
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <PersonalSchedulesEditPage />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-    });
-
-    test("Is populated with the data provided", async () => {
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <PersonalSchedulesEditPage />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-
-      await screen.findByTestId("PersonalScheduleForm-id");
-
-      const idField = screen.getByTestId("PersonalScheduleForm-id");
-      const nameField = screen.getByTestId("PersonalScheduleForm-name");
-      const descriptionField = screen.getByTestId(
-        "PersonalScheduleForm-description",
-      );
-      const quarterField = document.querySelector(
-        "#PersonalScheduleForm-quarter",
-      );
-      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
-
-      expect(idField).toBeInTheDocument();
-      expect(idField).toHaveValue("17");
-      expect(nameField).toBeInTheDocument();
-      expect(nameField).toHaveValue("CS156");
-      expect(descriptionField).toBeInTheDocument();
-      expect(descriptionField).toHaveValue("My Winter Courses");
-      expect(quarterField).toBeInTheDocument();
-
-      expect(submitButton).toHaveTextContent("Update");
-
-      fireEvent.change(nameField, { target: { value: "Fall Courses" } });
-      fireEvent.change(descriptionField, {
-        target: { value: "My Plan for Fall" },
-      });
-      fireEvent.change(quarterField, { target: { value: "20222" } });
-
-      fireEvent.click(submitButton);
-
-      await waitFor(() => expect(mockToast).toBeCalled());
-      expect(mockToast).toBeCalledWith(
-        "PersonalSchedule Updated - id: 17 name: Fall Courses",
-      );
-
-      expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
-
-      expect(axiosMock.history.put.length).toBe(1); // times called
-      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
-      expect(axiosMock.history.put[0].data).toBe(
-        JSON.stringify({
-          user: {
-            id: 1,
-            email: "phtcon@ucsb.edu",
-            googleSub: "115856948234298493496",
-            pictureUrl:
-              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-            fullName: "Phill Conrad",
-            givenName: "Phill",
-            familyName: "Conrad",
-            emailVerified: true,
-            locale: "en",
-            hostedDomain: "ucsb.edu",
-            admin: true,
-          },
-          name: "Fall Courses",
-          description: "My Plan for Fall",
-          quarter: "20222",
-        }),
-      ); // posted object
-    });
-  });
+       <QueryClientProvider client={queryClient}>
+         <MemoryRouter>
+           <PersonalSchedulesEditPage />
+         </MemoryRouter>
+       </QueryClientProvider>,
+     );
+     // await waitFor(() => {
+     //   expect(
+     //     screen.getByTestId(`${testId}-cell-row-0-col-id`)
+     //   ).toHaveTextContent("25");
+     // });
+     expect(
+       screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+     ).not.toBeInTheDocument();
+   });
+ });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -122,9 +122,9 @@ describe("PersonalSchedulesEditPage tests", () => {
           hostedDomain: "ucsb.edu",
           admin: true,
         },
-        description: "My Plan for Fall",
-        quarter: "20222",
-        name: "Fall Courses",
+        description: "My Plan for Winter",
+        quarter: "20221",
+        name: "Winter Courses",
       });
     });
 
@@ -156,8 +156,8 @@ describe("PersonalSchedulesEditPage tests", () => {
       const descriptionField = screen.getByTestId(
         "PersonalScheduleForm-description",
       );
-      const quarterField = document.querySelector(
-        "#PersonalScheduleForm-quarter",
+      const quarterField = screen.getByTestId(
+        "PersonalScheduleForm-quarter",
       );
       const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
@@ -168,20 +168,19 @@ describe("PersonalSchedulesEditPage tests", () => {
       expect(descriptionField).toBeInTheDocument();
       expect(descriptionField).toHaveValue("My Winter Courses");
       expect(quarterField).toBeInTheDocument();
-
+      expect(quarterField).toHaveValue("W22")
       expect(submitButton).toHaveTextContent("Update");
 
-      fireEvent.change(nameField, { target: { value: "Fall Courses" } });
+      fireEvent.change(nameField, { target: { value: "Winter Courses" } });
       fireEvent.change(descriptionField, {
-        target: { value: "My Plan for Fall" },
+        target: { value: "My Plan for Winter" },
       });
-      fireEvent.change(quarterField, { target: { value: "20222" } });
 
       fireEvent.click(submitButton);
 
       await waitFor(() => expect(mockToast).toBeCalled());
       expect(mockToast).toBeCalledWith(
-        "PersonalSchedule Updated - id: 17 name: Fall Courses",
+        "PersonalSchedule Updated - id: 17 name: Winter Courses",
       );
 
       expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
@@ -204,9 +203,9 @@ describe("PersonalSchedulesEditPage tests", () => {
             hostedDomain: "ucsb.edu",
             admin: true,
           },
-          name: "Fall Courses",
-          description: "My Plan for Fall",
-          quarter: "20222",
+          name: "Winter Courses",
+          description: "My Plan for Winter",
+          quarter: "20221",
         }),
       ); // posted object
     });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -156,9 +156,7 @@ describe("PersonalSchedulesEditPage tests", () => {
       const descriptionField = screen.getByTestId(
         "PersonalScheduleForm-description",
       );
-      const quarterField = screen.getByTestId(
-        "PersonalScheduleForm-quarter",
-      );
+      const quarterField = screen.getByTestId("PersonalScheduleForm-quarter");
       const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
       expect(idField).toBeInTheDocument();
@@ -168,7 +166,7 @@ describe("PersonalSchedulesEditPage tests", () => {
       expect(descriptionField).toBeInTheDocument();
       expect(descriptionField).toHaveValue("My Winter Courses");
       expect(quarterField).toBeInTheDocument();
-      expect(quarterField).toHaveValue("W22")
+      expect(quarterField).toHaveValue("W22");
       expect(submitButton).toHaveTextContent("Update");
 
       fireEvent.change(nameField, { target: { value: "Winter Courses" } });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -1,4 +1,5 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, waitFor, screen, getByTestId, getByLabelText } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
@@ -7,24 +8,188 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("PersonalSchedulesEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-  axiosMock
-    .onGet("/api/currentUser")
-    .reply(200, apiCurrentUserFixtures.userOnly);
-  axiosMock
-    .onGet("/api/systemInfo")
-    .reply(200, systemInfoFixtures.showingNeither);
+  describe("when the backend doesn't return data", () => {
 
-  const queryClient = new QueryClient();
-  test("renders without crashing", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <PersonalSchedulesEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-  });
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/personalschedules", { params: { id: 17 } }).timeout();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+
+        const restoreConsole = mockConsole();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalSchedulesEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        await screen.findByText("Edit Personal Schedule");
+        expect(screen.queryByTestId("PersonalScheduleForm-name")).not.toBeInTheDocument();
+        restoreConsole();
+    });
+});
+
+describe("tests where backend is working normally", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/personalschedules", { params: { id: 17 } }).reply(200, {
+          id: 17,
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          description: "My Winter Courses",
+          quarter: "20221",
+          name: "CS156",
+        });
+        axiosMock.onPut('/api/personalschedules').reply(200, {
+          id: 17,
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          description: "My Plan for Fall",
+          quarter: "20224",
+          name: "Fall Courses",
+        });
+    });
+
+    const queryClient = new QueryClient();
+
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalSchedulesEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("Is populated with the data provided", async () => {
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalSchedulesEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await screen.findByTestId("PersonalScheduleForm-id");
+
+        const idField = screen.getByTestId("PersonalScheduleForm-id");
+        const nameField = screen.getByTestId("PersonalScheduleForm-name");
+        const descriptionField = screen.getByTestId("PersonalScheduleForm-description");
+        const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
+        const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+        expect(idField).toBeInTheDocument();
+        expect(idField).toHaveValue("17");
+        expect(nameField).toBeInTheDocument();
+        expect(nameField).toHaveValue("CS156");
+        expect(descriptionField).toBeInTheDocument();
+        expect(descriptionField).toHaveValue("My Winter Courses");
+        expect(quarterField).toBeInTheDocument();
+
+        expect(submitButton).toHaveTextContent("Update");
+
+
+        fireEvent.change(nameField, { target: { value: 'Fall Courses' } });
+        fireEvent.change(descriptionField, { target: { value: 'My Plan for Fall' } });
+        userEvent.selectOptions(quarterField, '20224');
+        //fireEvent.change(quarterField, { target: { value: '20224' } });
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockToast).toBeCalled());
+        expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 17 name: Fall Courses");
+        
+        expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
+
+        expect(axiosMock.history.put.length).toBe(1); // times called
+        expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+        expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          name: "Fall Courses",
+          description: "My Plan for Fall",
+          quarter: "20224",
+        })); // posted object
+    });
+   
+});
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, waitFor, screen, getByTestId, getByLabelText } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
@@ -110,7 +110,7 @@ describe("tests where backend is working normally", () => {
             admin: true,
           },
           description: "My Plan for Fall",
-          quarter: "20224",
+          quarter: "20222",
           name: "Fall Courses",
         });
     });
@@ -154,12 +154,10 @@ describe("tests where backend is working normally", () => {
         expect(quarterField).toBeInTheDocument();
 
         expect(submitButton).toHaveTextContent("Update");
-
-
+        
         fireEvent.change(nameField, { target: { value: 'Fall Courses' } });
         fireEvent.change(descriptionField, { target: { value: 'My Plan for Fall' } });
-        userEvent.selectOptions(quarterField, '20224');
-        //fireEvent.change(quarterField, { target: { value: '20224' } });
+        fireEvent.change(quarterField, { target: { value: '20222' } });
 
         fireEvent.click(submitButton);
 
@@ -187,7 +185,7 @@ describe("tests where backend is working normally", () => {
           },
           name: "Fall Courses",
           description: "My Plan for Fall",
-          quarter: "20224",
+          quarter: "20222",
         })); // posted object
     });
    


### PR DESCRIPTION
Changed file: 
- frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
- frontend/src/main/components/Quarters/SingleQuarterDropdown.js
- frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
- frontend/src/stories/pages/HomePage/PersonalSchedules/PersonalSchedulesEditPage.stories.js
- frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
- frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js

Dokku deployment: https://proj-courses-cory-zhao-dev.dokku-08.cs.ucsb.edu

This PR adds the PersonalScheduleEditPage. This page can edit the fields of any PersonalSchedule. After clicking edit, it should display the correct contents of the PersonalSchedule in the form and when you edit any changes, the changes should be consistent on the frontend and backend. Furthermore, each personal schedule contains a CoursesTable that displays all the courses linked to the PersonalSchedule by psId. When you delete a course on the edit page, it should delete the course on the frontend and backend. 

How to test:
Note - with each step, look in swagger to see the contents are correctly filling the backend

1. Add 2 schedules and click edit on the schedules. Check the form to see if the fields are filled in with the correct contents.
2. Edit the form. Check that the form is edited in frontend and backend.
3. Add 2 courses (you should add courses that have no sections and are allowed with the quarter you chose). Have each course link to a separate schedule. Check each PersonalSchedule to see only the linked course is in the CourseTable. 
4. Delete a course from the table. Check to see that course is deleted in the frontend and backend.

<img width="1338" alt="Screenshot 2024-03-06 at 3 02 45 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-4/assets/91992519/d6247309-fc79-4eef-ba58-fb70c78c5675">

Closes #11 