### PR TITLE
BUG: Can't immediately search for graduate courses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ build/
 
 ### Local Configuration ###
 .env
+
+.DS_Store

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -74,7 +74,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
               levels={allTheLevels}
               level={level}
               setLevel={setLevel}
-              controlId={"BasicSearch.Level"}
+              controlId={"BasicSearch.CourseLevel"}
             />
           </Col>
         </Row>

--- a/frontend/src/main/components/Levels/SingleLevelDropdown.js
+++ b/frontend/src/main/components/Levels/SingleLevelDropdown.js
@@ -9,15 +9,19 @@ const SingleLevelDropdown = ({
   label = "Course Level",
 }) => {
   const localSearchLevel = localStorage.getItem(controlId);
+  if (!localSearchLevel) {
+    localStorage.setItem(controlId, "U");
+  }
   const [levelState, setLevelState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
     localSearchLevel || "U",
   );
 
   const handleLeveltoChange = (event) => {
-    localStorage.setItem(controlId, event.target.value);
-    setLevelState(event.target.value);
-    setLevel(event.target.value);
+    const selectedLevel = event.target.value;
+    localStorage.setItem(controlId, selectedLevel);
+    setLevelState(selectedLevel);
+    setLevel(selectedLevel);
     if (onChange != null) {
       onChange(event);
     }

--- a/frontend/src/main/components/Levels/SingleLevelDropdown.js
+++ b/frontend/src/main/components/Levels/SingleLevelDropdown.js
@@ -9,19 +9,15 @@ const SingleLevelDropdown = ({
   label = "Course Level",
 }) => {
   const localSearchLevel = localStorage.getItem(controlId);
-  if (!localSearchLevel) {
-    localStorage.setItem(controlId, "U");
-  }
   const [levelState, setLevelState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
     localSearchLevel || "U",
   );
 
   const handleLeveltoChange = (event) => {
-    const selectedLevel = event.target.value;
-    localStorage.setItem(controlId, selectedLevel);
-    setLevelState(selectedLevel);
-    setLevel(selectedLevel);
+    localStorage.setItem(controlId, event.target.value);
+    setLevelState(event.target.value);
+    setLevel(event.target.value);
     if (onChange != null) {
       onChange(event);
     }


### PR DESCRIPTION
Fixed bug with course searches not showing graduate courses on the first attempt.
Main change was in the file: BasicCourseSearchForm.js
In this file the form stored the value in BasicSearch.Level but accessed values from BasicSearch.CourseLevel
I changed this value to be consistent.

Closes: #13 