### PR TITLE
BUG: Can't immediately search for graduate courses

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -74,7 +74,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
               levels={allTheLevels}
               level={level}
               setLevel={setLevel}
-              controlId={"BasicSearch.Level"}
+              controlId={"BasicSearch.CourseLevel"}
             />
           </Col>
         </Row>

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -48,7 +48,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
   });
 
@@ -58,7 +58,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20204");
@@ -73,12 +73,12 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     const expectedKey = "BasicSearch.Subject-option-MATH";
     await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument)
+      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
     );
 
     const selectSubject = screen.getByLabelText("Subject Area");
@@ -93,7 +93,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
@@ -115,7 +115,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm fetchJSON={fetchJSONSpy} />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     const expectedFields = {
@@ -126,7 +126,7 @@ describe("BasicCourseSearchForm tests", () => {
 
     const expectedKey = "BasicSearch.Subject-option-ANTH";
     await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument)
+      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
     );
 
     const selectQuarter = screen.getByLabelText("Quarter");
@@ -143,7 +143,7 @@ describe("BasicCourseSearchForm tests", () => {
 
     expect(fetchJSONSpy).toHaveBeenCalledWith(
       expect.any(Object),
-      expectedFields
+      expectedFields,
     );
   });
 
@@ -164,12 +164,12 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm fetchJSON={fetchJSONSpy} />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     const expectedKey = "BasicSearch.Subject-option-MATH";
     await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument)
+      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
     );
 
     const selectQuarter = screen.getByLabelText("Quarter");
@@ -195,15 +195,15 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     // Make sure the first and last options
     expect(
-      await screen.findByTestId(/BasicSearch.Quarter-option-0/)
+      await screen.findByTestId(/BasicSearch.Quarter-option-0/),
     ).toHaveValue("20211");
     expect(
-      await screen.findByTestId(/BasicSearch.Quarter-option-3/)
+      await screen.findByTestId(/BasicSearch.Quarter-option-3/),
     ).toHaveValue("20214");
   });
 
@@ -222,7 +222,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm fetchJSON={fetchJSONSpy} />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     const expectedKey_Quarter = "BasicSearch.Quarter-option-0";

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -48,7 +48,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
   });
 
@@ -58,7 +58,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20204");
@@ -73,12 +73,12 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     const expectedKey = "BasicSearch.Subject-option-MATH";
     await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
+      expect(screen.getByTestId(expectedKey).toBeInTheDocument)
     );
 
     const selectSubject = screen.getByLabelText("Subject Area");
@@ -93,7 +93,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
@@ -115,7 +115,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm fetchJSON={fetchJSONSpy} />
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     const expectedFields = {
@@ -126,7 +126,7 @@ describe("BasicCourseSearchForm tests", () => {
 
     const expectedKey = "BasicSearch.Subject-option-ANTH";
     await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
+      expect(screen.getByTestId(expectedKey).toBeInTheDocument)
     );
 
     const selectQuarter = screen.getByLabelText("Quarter");
@@ -143,7 +143,7 @@ describe("BasicCourseSearchForm tests", () => {
 
     expect(fetchJSONSpy).toHaveBeenCalledWith(
       expect.any(Object),
-      expectedFields,
+      expectedFields
     );
   });
 
@@ -164,12 +164,12 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm fetchJSON={fetchJSONSpy} />
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     const expectedKey = "BasicSearch.Subject-option-MATH";
     await waitFor(() =>
-      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
+      expect(screen.getByTestId(expectedKey).toBeInTheDocument)
     );
 
     const selectQuarter = screen.getByLabelText("Quarter");
@@ -195,19 +195,19 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     // Make sure the first and last options
     expect(
-      await screen.findByTestId(/BasicSearch.Quarter-option-0/),
+      await screen.findByTestId(/BasicSearch.Quarter-option-0/)
     ).toHaveValue("20211");
     expect(
-      await screen.findByTestId(/BasicSearch.Quarter-option-3/),
+      await screen.findByTestId(/BasicSearch.Quarter-option-3/)
     ).toHaveValue("20214");
   });
 
-    test("when I click submit, there is a Quarter, Subject, and CourseLeve feild by default", async () => {
+  test("when I click submit, there is a Quarter, Subject, and CourseLeve feild by default", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {
       sampleKey: "sampleValue",
@@ -222,7 +222,7 @@ describe("BasicCourseSearchForm tests", () => {
         <MemoryRouter>
           <BasicCourseSearchForm fetchJSON={fetchJSONSpy} />
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     const expectedKey_Quarter = "BasicSearch.Quarter-option-0";

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -206,4 +206,30 @@ describe("BasicCourseSearchForm tests", () => {
       await screen.findByTestId(/BasicSearch.Quarter-option-3/),
     ).toHaveValue("20214");
   });
+
+  test("when I click submit, there is a Quarter, Subject, and CourseLeve feild by default", async () => {
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+    const sampleReturnValue = {
+      sampleKey: "sampleValue",
+    };
+
+    const fetchJSONSpy = jest.fn();
+
+    fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BasicCourseSearchForm fetchJSON={fetchJSONSpy} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedKey_Quarter = "BasicSearch.Quarter-option-0";
+    expect(screen.getByTestId(expectedKey_Quarter).toBeInTheDocument);
+    const expectedKey_Subject = "BasicSearch.Subject-option-ANTH";
+    expect(screen.getByTestId(expectedKey_Subject).toBeInTheDocument);
+    const expectedKey_CourseLevel = "BasicSearch.CourseLevel-option-0";
+    expect(screen.getByTestId(expectedKey_CourseLevel).toBeInTheDocument);
+  });
 });

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -207,7 +207,7 @@ describe("BasicCourseSearchForm tests", () => {
     ).toHaveValue("20214");
   });
 
-  test("when I click submit, there is a Quarter, Subject, and CourseLeve feild by default", async () => {
+    test("when I click submit, there is a Quarter, Subject, and CourseLeve feild by default", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {
       sampleKey: "sampleValue",
@@ -226,10 +226,10 @@ describe("BasicCourseSearchForm tests", () => {
     );
 
     const expectedKey_Quarter = "BasicSearch.Quarter-option-0";
-    expect(screen.getByTestId(expectedKey_Quarter)).toBeInTheDocument;
+    expect(screen.getByTestId(expectedKey_Quarter)).toBeInTheDocument();
     const expectedKey_Subject = "BasicSearch.Subject-option-ANTH";
-    expect(screen.getByTestId(expectedKey_Subject)).toBeInTheDocument;
+    expect(screen.getByTestId(expectedKey_Subject)).toBeInTheDocument();
     const expectedKey_CourseLevel = "BasicSearch.CourseLevel-option-0";
-    expect(screen.getByTestId(expectedKey_CourseLevel)).toBeInTheDocument;
+    expect(screen.getByTestId(expectedKey_CourseLevel)).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -226,10 +226,10 @@ describe("BasicCourseSearchForm tests", () => {
     );
 
     const expectedKey_Quarter = "BasicSearch.Quarter-option-0";
-    expect(screen.getByTestId(expectedKey_Quarter).toBeInTheDocument);
+    expect(screen.getByTestId(expectedKey_Quarter)).toBeInTheDocument;
     const expectedKey_Subject = "BasicSearch.Subject-option-ANTH";
-    expect(screen.getByTestId(expectedKey_Subject).toBeInTheDocument);
+    expect(screen.getByTestId(expectedKey_Subject)).toBeInTheDocument;
     const expectedKey_CourseLevel = "BasicSearch.CourseLevel-option-0";
-    expect(screen.getByTestId(expectedKey_CourseLevel).toBeInTheDocument);
+    expect(screen.getByTestId(expectedKey_CourseLevel)).toBeInTheDocument;
   });
 });

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -207,7 +207,7 @@ describe("BasicCourseSearchForm tests", () => {
     ).toHaveValue("20214");
   });
 
-  test("when I click submit, there is a Quarter, Subject, and CourseLeve feild by default", async () => {
+  test("when I click submit, there is a Quarter, Subject, and CourseLevel field by default", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {
       sampleKey: "sampleValue",

--- a/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
+++ b/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
@@ -45,8 +45,8 @@ describe("SingleLevelDropdown tests", () => {
 
     expect(await screen.findByLabelText("Course Level")).toBeInTheDocument();
     const selectLevel = screen.getByLabelText("Course Level");
-    userEvent.selectOptions(selectLevel, "U");
-    expect(setLevel).toBeCalledWith("U");
+    userEvent.selectOptions(selectLevel, "G");
+    expect(setLevel).toBeCalledWith("G");
   });
 
   test("if I pass a non-null onChange, it gets called when the value changes", async () => {
@@ -63,14 +63,14 @@ describe("SingleLevelDropdown tests", () => {
 
     expect(await screen.findByLabelText("Course Level")).toBeInTheDocument();
     const selectLevel = screen.getByLabelText("Course Level");
-    userEvent.selectOptions(selectLevel, "U");
+    userEvent.selectOptions(selectLevel, "L");
 
-    await waitFor(() => expect(setLevel).toBeCalledWith("U"));
+    await waitFor(() => expect(setLevel).toBeCalledWith("L"));
     await waitFor(() => expect(onChange).toBeCalledTimes(1));
 
     // x.mock.calls[0][0] is the first argument of the first call to the jest.fn() mock x
     const event = onChange.mock.calls[0][0];
-    expect(event.target.value).toBe("U");
+    expect(event.target.value).toBe("L");
   });
 
   test("default label is Course Level", async () => {
@@ -102,7 +102,7 @@ describe("SingleLevelDropdown tests", () => {
 
   test("when localstorage has a value, it is passed to useState", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
-    getItemSpy.mockImplementation(() => "U");
+    getItemSpy.mockImplementation(() => "S");
 
     const setLevelStateSpy = jest.fn();
     useState.mockImplementation((x) => [x, setLevelStateSpy]);
@@ -116,7 +116,7 @@ describe("SingleLevelDropdown tests", () => {
       />,
     );
 
-    await waitFor(() => expect(useState).toBeCalledWith("U"));
+    await waitFor(() => expect(useState).toBeCalledWith("S"));
   });
 
   test("when localstorage has no value, U is passed to useState", async () => {


### PR DESCRIPTION
 Changed files:
- frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
- frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
- frontend/src/tests/components/Levels/SingleLevelDropdown.test.js

This pull request addresses the bug that wouldn't allow the user to search for graduate courses on the first search.

The issue was caused by the controlId for the course level being set wrong in BasicCourseSearchForm. This meant that whenever the page was loaded, the value that was shown in the CourseLevel drop-down box was not the level being searched. However if the user interacted with the drop-down menu to change this value, SingleLevelDropdown would take over and set the right value in the search. (This is what allowed the table to be right on the second search)
So the bug wasn't only for graduate courses but would affect any course level when the page was reloaded and submitted with a course level not previously submitted.

One way to reproduce this bug:
- Set the course level to something other than already shown in the box (I choose Undergrad-Lower-Division)
  - (This will update the value being used through SingleLevelDropdown, so everything should be set correctly)
- Press submit
  - (This should give the correct table for that course level)
- Change the level field to any other value and without submitting, refresh the page (I choose Graduate)
- Finally submit, the bug should cause the table to populate with values that aren't from the selected course level
  - (In my case this was the table for Undergrad-Upper-Division)
- To test that the second search works, change the course level to a random value and then change it back to Graduate
  - (It should now have the right table for Graduate courses)
  
<img width="908" alt="Screenshot 2024-02-29 at 10 25 13 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-4/assets/33041154/5e33fedb-2353-4c05-afd7-7fdf642e8185">

After changing BasicCourseSearchForm, the search page now recognizes the value in the drop-down menu without the need to change it to update the value being searched. You can test this fix with the same steps as above, although this time the table generated should be correct all the time.

To help test this fix, in the code I added tests in BasicCourseSearchForm.test to make sure that the page loads with values for the conrolId: CourseLevel (along with confirming the other controlId names are set correctly).
I also changed tests in SingleLevelDropdown.test to test course level values other than the default ("U")

Test initial bug at: https://courses.dokku-00.cs.ucsb.edu/
Dokku site at: https://proj-colefoster08-dev.dokku-08.cs.ucsb.edu

Closes: #13 