### PR TITLE
FEATURE: Add frontend for job to update all courses in a range of quarters

### DIFF
--- a/frontend/src/main/components/Jobs/UpdateCoursesByQuarterRangeJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesByQuarterRangeJobForm.js
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { Form, Button, Container, Row, Col } from "react-bootstrap";
+
+import { quarterRange } from "main/utils/quarterUtilities";
+
+import { useSystemInfo } from "main/utils/systemInfo";
+import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
+
+const UpdateCoursesByQuarterRangeJobForm = ({ callback }) => {
+  const { data: systemInfo } = useSystemInfo();
+
+  // Stryker disable OptionalChaining
+  const startQtr = systemInfo?.startQtrYYYYQ || "20211";
+  const endQtr = systemInfo?.endQtrYYYYQ || "20214";
+  // Stryker enable OptionalChaining
+
+  const quarters = quarterRange(startQtr, endQtr);
+
+  // Stryker disable all : not sure how to test/mock local storage
+  const localStartQuarter = localStorage.getItem("BasicSearch.StartQuarter");
+  const localEndQuarter = localStorage.getItem("BasicSearch.EndQuarter");
+
+  const [startQuarter, setStartQuarter] = useState(
+    localStartQuarter || quarters[0].yyyyq,
+  );
+  const [endQuarter, setEndQuarter] = useState(
+    localEndQuarter || quarters[0].yyyyq,
+  );
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    callback({ startQuarter, endQuarter });
+  };
+
+  // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
+  const padding = { paddingTop: 10, paddingBottom: 10 };
+  // Stryker restore all
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Container>
+        <Row>
+          <Col md="auto">
+            <SingleQuarterDropdown
+              quarters={quarters}
+              quarter={startQuarter}
+              setQuarter={setStartQuarter}
+              controlId={"BasicSearch.StartQuarter"}
+              label={"Start Quarter"}
+            />
+          </Col>
+          <Col md="auto">
+            <SingleQuarterDropdown
+              quarters={quarters}
+              quarter={endQuarter}
+              setQuarter={setEndQuarter}
+              controlId={"BasicSearch.EndQuarter"}
+              label={"End Quarter"}
+            />
+          </Col>
+        </Row>
+        <Row style={padding}>
+          <Col md="auto">
+            <Button
+              variant="primary"
+              type="submit"
+              data-testid="updateCoursesByQuarterRange"
+            >
+              Update Courses
+            </Button>
+          </Col>
+        </Row>
+      </Container>
+    </Form>
+  );
+};
+
+export default UpdateCoursesByQuarterRangeJobForm;

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -9,6 +9,7 @@ import JobComingSoon from "main/components/Jobs/JobComingSoon";
 import { useBackendMutation } from "main/utils/useBackend";
 import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
 import UpdateCoursesByQuarterJobForm from "main/components/Jobs/UpdateCoursesByQuarterJobForm";
+import UpdateCoursesByQuarterRangeJobForm from "main/components/Jobs/UpdateCoursesByQuarterRangeJobForm";
 
 const AdminJobsPage = () => {
   const refreshJobsIntervalMilliseconds = 5000;
@@ -42,6 +43,11 @@ const AdminJobsPage = () => {
     method: "POST",
   });
 
+  const objectToAxiosParamsUpdateCoursesByQuarterRangeJob = (data) => ({
+    url: `/api/jobs/launch/updateCoursesRangeOfQuarters?start_quarterYYYYQ=${data.startQuarter}&end_quarterYYYYQ=${data.endQuarter}`,
+    method: "POST",
+  });
+
   // Stryker disable all
   const updateCoursesJobMutation = useBackendMutation(
     objectToAxiosParamsUpdateCoursesJob,
@@ -53,6 +59,11 @@ const AdminJobsPage = () => {
     {},
     ["/api/jobs/all"],
   );
+  const updateCoursesByQuarterRangeJobMutation = useBackendMutation(
+    objectToAxiosParamsUpdateCoursesByQuarterRangeJob,
+    {},
+    ["/api/jobs/all"],
+  );
   // Stryker restore all
 
   const submitUpdateCoursesJob = async (data) => {
@@ -61,6 +72,10 @@ const AdminJobsPage = () => {
 
   const submitUpdateCoursesByQuarterJob = async (data) => {
     updateCoursesByQuarterJobMutation.mutate(data);
+  };
+
+  const submitUpdateCoursesByQuarterRangeJob = async (data) => {
+    updateCoursesByQuarterRangeJobMutation.mutate(data);
   };
 
   // Stryker disable all
@@ -93,6 +108,14 @@ const AdminJobsPage = () => {
       form: (
         <UpdateCoursesByQuarterJobForm
           callback={submitUpdateCoursesByQuarterJob}
+        />
+      ),
+    },
+    {
+      name: "Update Courses Database by quarter range",
+      form: (
+        <UpdateCoursesByQuarterRangeJobForm
+          callback={submitUpdateCoursesByQuarterRangeJob}
         />
       ),
     },

--- a/frontend/src/stories/components/Jobs/UpdateCoursesByQuarterRangeJobForm.stories.js
+++ b/frontend/src/stories/components/Jobs/UpdateCoursesByQuarterRangeJobForm.stories.js
@@ -1,0 +1,31 @@
+import React from "react";
+
+import UpdateCoursesByQuarterRangeJobForm from "main/components/Jobs/UpdateCoursesByQuarterRangeJobForm";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+export default {
+  title: "components/Jobs/UpdateCoursesByQuarterRangeJobForm",
+  component: UpdateCoursesByQuarterRangeJobForm,
+  parameters: {
+    mockData: [
+      {
+        url: "/api/systemInfo",
+        method: "GET",
+        status: 200,
+        response: systemInfoFixtures.showingBoth,
+      },
+    ],
+  },
+};
+
+const Template = (args) => {
+  return <UpdateCoursesByQuarterRangeJobForm {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  callback: (data) => {
+    console.log("Submit was clicked, data=", data);
+  },
+};

--- a/frontend/src/tests/components/Jobs/UpdateCoursesByQuarterRangeJobForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateCoursesByQuarterRangeJobForm.test.js
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import UpdateCoursesByQuarterRangeJobForm from "main/components/Jobs/UpdateCoursesByQuarterRangeJobForm";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+const queryClient = new QueryClient();
+
+describe("UpdateCoursesByQuarterRangeJobForm tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  it("renders correctly", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UpdateCoursesByQuarterRangeJobForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText(/Update Courses/)).toBeInTheDocument();
+  });
+
+  test("renders without crashing when fallback values are used", async () => {
+    axiosMock.onGet("/api/systemInfo").reply(200, {
+      springH2ConsoleEnabled: false,
+      showSwaggerUILink: false,
+      startQtrYYYYQ: null, // use fallback value
+      endQtrYYYYQ: null, // use fallback value
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UpdateCoursesByQuarterRangeJobForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    // Make sure the first and last options
+    expect(
+      await screen.findByTestId(/BasicSearch.StartQuarter-option-0/),
+    ).toHaveValue("20211");
+    expect(
+      await screen.findByTestId(/BasicSearch.StartQuarter-option-3/),
+    ).toHaveValue("20214");
+    expect(
+      await screen.findByTestId(/BasicSearch.EndQuarter-option-0/),
+    ).toHaveValue("20211");
+    expect(
+      await screen.findByTestId(/BasicSearch.EndQuarter-option-3/),
+    ).toHaveValue("20214");
+  });
+});

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -178,4 +178,47 @@ describe("AdminJobsPage tests", () => {
       "/api/jobs/launch/updateQuarterCourses?quarterYYYYQ=20211",
     );
   });
+
+  test("user can submit the update course data by quarter range job", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminJobsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByText("Update Courses Database by quarter range"),
+    ).toBeInTheDocument();
+
+    const updateCoursesButton = screen.getByText(
+      "Update Courses Database by quarter range",
+    );
+    expect(updateCoursesButton).toBeInTheDocument();
+    updateCoursesButton.click();
+
+    expect(await screen.findByTestId("TestJobForm-fail")).toBeInTheDocument();
+
+    const submitButton = screen.getByTestId("updateCoursesByQuarterRange");
+
+    const expectedKey = "BasicSearch.Subject-option-ANTH";
+    await waitFor(() =>
+      expect(screen.getByTestId(expectedKey).toBeInTheDocument),
+    );
+
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20212");
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20213");
+    expect(submitButton).toBeInTheDocument();
+
+    submitButton.click();
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].url).toBe(
+      "/api/jobs/launch/updateCoursesRangeOfQuarters?start_quarterYYYYQ=20212&end_quarterYYYYQ=20213",
+    );
+  });
 });


### PR DESCRIPTION
Files Changed:
- frontend/src/main/components/Jobs/UpdateCoursesByQuarterRangeJobForm.js
- frontend/src/stories/components/Jobs/UpdateCoursesByQuarterRangeJobForm.stories.js
- frontend/src/tests/components/Jobs/UpdateCoursesByQuarterRangeJobForm.test.js
- frontend/src/main/pages/AdminJobsPage.js
- frontend/src/tests/pages/AdminJobsPage.test.js

This pull request adds the frontend for updating courses using a range of quarters.

To add this feature I based UpdateCoursesByQuarterRangeJobForm off of UpdateCoursesByQuarterJobForm. From this base I added a field for an additional quarter input, and created labels and controlIds for the start and end quarters of the form. I then added to the existing AdminJobsPage to call the backend api with the values input through the form. Finally I added to the test files for every file changed in order to maintain 100% coverage and mutations killed.

Steps to test:
- Log in to the site to have admin access
- Navigate to the Admin tab and then 'Manage Jobs'
- The feature is located under the title 'Update Courses Database by quarter range'
- From here enter a value for the start and end of the range
  - (This seems to take a long time, especially if the range is long)

<img width="1613" alt="Screenshot 2024-03-02 at 9 53 17 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-4/assets/33041154/9ae52598-4bb5-42f0-a56a-b1f496d988e0">

Dokku site at: https://proj-colefoster08-dev.dokku-08.cs.ucsb.edu/

Closes: #9 