### PR TITLE
FEATURE: More descriptive error message on personal schedule

### DIFF
--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -38,9 +38,10 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
 
   useEffect(() => {
     // Stryker disable all : not sure how to test/mock local storage
-    if (localSchedule && schedules && schedules.length > 0) {
-      schedules.find((sch) => sch === localSchedule);
-    }
+    // if (localSchedule && schedules && schedules.length > 0) {
+      // schedules.find((sch) => sch === localSchedule);
+
+    // }
     // Stryker restore all
 
     if (schedules && schedules.length > 0 && !localSchedule) {

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -37,10 +37,12 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
   // Stryker restore all
 
   useEffect(() => {
+    if (localSchedule && schedules && schedules.length > 0) {
+      schedules.find((sch) => sch === localSchedule);
+    }
+    
     if (schedules && schedules.length > 0 && !localSchedule) {
-      if (localSchedule && schedules && schedules.length > 0) {
-        schedules.find((sch) => sch === localSchedule);
-      }
+
       setSchedule(schedules[0].id);
       // Stryker disable all : not sure how to test/mock local storage
       localStorage.setItem("CourseForm-psId", schedules[0].id);

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -37,12 +37,10 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
   // Stryker restore all
 
   useEffect(() => {
-
-    if (localSchedule && schedules && schedules.length > 0) {
-      schedules.find((sch) => sch === localSchedule);
-    }
-
     if (schedules && schedules.length > 0 && !localSchedule) {
+      if (localSchedule && schedules && schedules.length > 0) {
+        schedules.find((sch) => sch === localSchedule);
+      }
       setSchedule(schedules[0].id);
       // Stryker disable all : not sure how to test/mock local storage
       localStorage.setItem("CourseForm-psId", schedules[0].id);

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -37,12 +37,13 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
   // Stryker restore all
 
   useEffect(() => {
+    // Stryker disable all : not sure how to test/mock local storage
     if (localSchedule && schedules && schedules.length > 0) {
       schedules.find((sch) => sch === localSchedule);
     }
-    
-    if (schedules && schedules.length > 0 && !localSchedule) {
+    // Stryker restore all
 
+    if (schedules && schedules.length > 0 && !localSchedule) {
       setSchedule(schedules[0].id);
       // Stryker disable all : not sure how to test/mock local storage
       localStorage.setItem("CourseForm-psId", schedules[0].id);

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -38,10 +38,9 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
 
   useEffect(() => {
     // Stryker disable all : not sure how to test/mock local storage
-    // if (localSchedule && schedules && schedules.length > 0) {
-      // schedules.find((sch) => sch === localSchedule);
-
-    // }
+    if (localSchedule && schedules && schedules.length > 0) {
+      schedules.find((sch) => sch === localSchedule);
+    }
     // Stryker restore all
 
     if (schedules && schedules.length > 0 && !localSchedule) {

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -37,6 +37,11 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
   // Stryker restore all
 
   useEffect(() => {
+
+    if (localSchedule && schedules && schedules.length > 0) {
+      schedules.find((sch) => sch === localSchedule);
+    }
+
     if (schedules && schedules.length > 0 && !localSchedule) {
       setSchedule(schedules[0].id);
       // Stryker disable all : not sure how to test/mock local storage

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -53,10 +53,10 @@ export default function CoursesCreatePage() {
     return <Navigate to="/courses/list" />;
   }
 
-  if (mutation.isError){
-    const psIdError = mutation.error.response.data?.message.includes('psId');
-    if ( psIdError) {
-      return ( 
+  if (mutation.isError) {
+    const psIdError = mutation.error.response.data?.message.includes("psId");
+    if (psIdError) {
+      return (
         <BasicLayout>
           <div className="pt-2">
             <h1>Create New Course</h1>
@@ -70,19 +70,18 @@ export default function CoursesCreatePage() {
           </div>
         </BasicLayout>
       );
-    }
-    else  {
-      return(
+    } else {
+      return (
         <BasicLayout>
-        <div className="pt-2">
-          <h1>Create New Course</h1>
-  
-          <CourseForm submitAction={onSubmit} />
-          <p data-testid="PSCourseCreate-Error">
-            Error: {mutation.error.response.data?.message}
-          </p>
-        </div>
-      </BasicLayout>
+          <div className="pt-2">
+            <h1>Create New Course</h1>
+
+            <CourseForm submitAction={onSubmit} />
+            <p data-testid="PSCourseCreate-Error">
+              Error: {mutation.error.response.data?.message}
+            </p>
+          </div>
+        </BasicLayout>
       );
     }
   }

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -52,21 +52,41 @@ export default function CoursesCreatePage() {
   if (isSuccess) {
     return <Navigate to="/courses/list" />;
   }
-  if (mutation.isError) {
-    return (
-      <BasicLayout>
+
+  if (mutation.isError){
+    const psIdError = mutation.error.response.data?.message.includes('psId');
+    if ( psIdError) {
+      return ( 
+        <BasicLayout>
+          <div className="pt-2">
+            <h1>Create New Course</h1>
+
+            <CourseForm submitAction={onSubmit} />
+            <p data-testid="PSCourseCreate-Error">
+              Error: {"Please select a personal schedule or create a new one."}
+              {/* Error : {mutation.error.response.data?.message} */}
+            </p>
+            {createButton()}
+          </div>
+        </BasicLayout>
+      );
+    }
+    else  {
+      return(
+        <BasicLayout>
         <div className="pt-2">
           <h1>Create New Course</h1>
-
+  
           <CourseForm submitAction={onSubmit} />
           <p data-testid="PSCourseCreate-Error">
-            Error: {"Please select a personal schedule or create a new one."}
+            Error: {mutation.error.response.data?.message}
           </p>
-          {createButton()}
         </div>
       </BasicLayout>
-    );
+      );
+    }
   }
+
   return (
     <BasicLayout>
       <div className="pt-2">

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -3,7 +3,7 @@ import CourseForm from "main/components/Courses/CourseForm";
 import { Navigate } from "react-router-dom";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
-import { Button} from "react-bootstrap";
+import { Button } from "react-bootstrap";
 
 export default function CoursesCreatePage() {
   const objectToAxiosParams = (course) => ({
@@ -23,15 +23,15 @@ export default function CoursesCreatePage() {
 
   const createButton = () => {
     return (
-        <Button
-            variant="primary"
-            href="/personalschedules/create"
-            style={{ float: "right" }}
-        >
-            Add Personal Schedule
-        </Button>
-    )
-  }
+      <Button
+        variant="primary"
+        href="/personalschedules/create"
+        style={{ float: "right" }}
+      >
+        Add Personal Schedule
+      </Button>
+    );
+  };
   const mutation = useBackendMutation(
     objectToAxiosParams,
     { onSuccess },
@@ -60,10 +60,10 @@ export default function CoursesCreatePage() {
 
           <CourseForm submitAction={onSubmit} />
           <p data-testid="PSCourseCreate-Error">
-            Error: {'Please select a personal schedule or create a new one.'}          
+            Error: {"Please select a personal schedule or create a new one."}
           </p>
           {createButton()}
-        </div> 
+        </div>
       </BasicLayout>
     );
   }

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -55,7 +55,7 @@ export default function CoursesCreatePage() {
 
   if (mutation.isError) {
     // const psIdError = mutation.error.response.data?.message.includes("psId");
-    const psIdError = mutation.error.response.status === 400;
+    const psIdError = mutation.error.response.status === 400 && mutation.error.response.data.message.includes("psId");
     if (psIdError) {
       return (
         <BasicLayout>

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -54,7 +54,8 @@ export default function CoursesCreatePage() {
   }
 
   if (mutation.isError) {
-    const psIdError = mutation.error.response.data?.message.includes("psId");
+    // const psIdError = mutation.error.response.data?.message.includes("psId");
+    const psIdError = mutation.error.response.status === 400;
     if (psIdError) {
       return (
         <BasicLayout>

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -48,7 +48,8 @@ export default function CoursesCreatePage() {
 
           <CourseForm submitAction={onSubmit} />
           <p data-testid="PSCourseCreate-Error">
-            Error: {mutation.error.response.data?.message}
+            Error: {'Please select a personal schedule or create a new one.'}
+            
           </p>
         </div>
       </BasicLayout>

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -3,6 +3,7 @@ import CourseForm from "main/components/Courses/CourseForm";
 import { Navigate } from "react-router-dom";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
+import { Button} from "react-bootstrap";
 
 export default function CoursesCreatePage() {
   const objectToAxiosParams = (course) => ({
@@ -20,6 +21,17 @@ export default function CoursesCreatePage() {
     );
   };
 
+  const createButton = () => {
+    return (
+        <Button
+            variant="primary"
+            href="/personalschedules/create"
+            style={{ float: "right" }}
+        >
+            Add Personal Schedule
+        </Button>
+    )
+  }
   const mutation = useBackendMutation(
     objectToAxiosParams,
     { onSuccess },
@@ -48,10 +60,10 @@ export default function CoursesCreatePage() {
 
           <CourseForm submitAction={onSubmit} />
           <p data-testid="PSCourseCreate-Error">
-            Error: {'Please select a personal schedule or create a new one.'}
-            
+            Error: {'Please select a personal schedule or create a new one.'}          
           </p>
-        </div>
+          {createButton()}
+        </div> 
       </BasicLayout>
     );
   }

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -129,7 +129,7 @@ describe("CoursesCreatePage tests", () => {
     const submitButton = screen.getByTestId("CourseForm-submit");
 
     fireEvent.change(psIdField, { target: { value: 13 } });
-    fireEvent.change(enrollCdField, { target: { value: '11111' } });
+    fireEvent.change(enrollCdField, { target: { value: "11111" } });
 
     expect(submitButton).toBeInTheDocument();
 
@@ -144,7 +144,6 @@ describe("CoursesCreatePage tests", () => {
         /Please select a personal schedule or create a new one./,
       ),
     ).not.toBeInTheDocument();
-
   });
 
   test("sets schedule and updates localStorage when schedules are available", async () => {
@@ -177,9 +176,7 @@ describe("CoursesCreatePage tests", () => {
         /Please select a personal schedule or create a new one./,
       ),
     ).not.toBeInTheDocument();
-
   });
-
 
   test("when you did not select schedule, we get an error", async () => {
     const queryClient = new QueryClient();
@@ -196,13 +193,15 @@ describe("CoursesCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(await screen.findByTestId("CourseForm-enrollCd")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("CourseForm-enrollCd"),
+    ).toBeInTheDocument();
 
     const psIdField = document.querySelector("#CourseForm-psId");
     const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 
-    fireEvent.change(psIdField, { target: { value: ''} });
+    fireEvent.change(psIdField, { target: { value: "" } });
     fireEvent.change(enrollCdField, { target: { value: "00026" } });
 
     expect(submitButton).toBeInTheDocument();
@@ -213,7 +212,6 @@ describe("CoursesCreatePage tests", () => {
     const PSError = screen.getByTestId("PSCourseCreate-Error");
     expect(PSError).toBeInTheDocument();
 
-
     expect(
       await screen.findByText(
         /Please select a personal schedule or create a new one./,
@@ -221,10 +219,10 @@ describe("CoursesCreatePage tests", () => {
     ).toBeInTheDocument();
 
     expect(
-        screen.queryByText(
-          /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
-        ),
-      ).not.toBeInTheDocument();
+      screen.queryByText(
+        /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
+      ),
+    ).not.toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByText(/Add Personal Schedule/)).toBeInTheDocument();
@@ -234,7 +232,7 @@ describe("CoursesCreatePage tests", () => {
     expect(button).toHaveAttribute("style", "float: right;");
   });
 
-  test("when you did not select schedule, we get an error", async () => {
+  test("when test message do not have psid, we get other error", async () => {
     const queryClient = new QueryClient();
 
     axiosMock.onPost("/api/courses/post").reply(400, {
@@ -249,13 +247,15 @@ describe("CoursesCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(await screen.findByTestId("CourseForm-enrollCd")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("CourseForm-enrollCd"),
+    ).toBeInTheDocument();
 
     const psIdField = document.querySelector("#CourseForm-psId");
     const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 
-    fireEvent.change(psIdField, { target: { value: ''} });
+    fireEvent.change(psIdField, { target: { value: "" } });
     fireEvent.change(enrollCdField, { target: { value: "00026" } });
 
     expect(submitButton).toBeInTheDocument();
@@ -266,21 +266,16 @@ describe("CoursesCreatePage tests", () => {
     const PSError = screen.getByTestId("PSCourseCreate-Error");
     expect(PSError).toBeInTheDocument();
 
-
     expect(
-      await screen.queryByText(
+      screen.queryByText(
         /Please select a personal schedule or create a new one./,
       ),
     ).not.toBeInTheDocument();
 
     expect(
-        screen.queryByText(
-          /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
-        ),
-      ).not.toBeInTheDocument();
-
+      screen.queryByText(
+        /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
+      ),
+    ).not.toBeInTheDocument();
   });
-  
-  
 });
-

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -232,50 +232,50 @@ describe("CoursesCreatePage tests", () => {
     expect(button).toHaveAttribute("style", "float: right;");
   });
 
-  // test("when test message do not have psid, we get other error", async () => {
-  //   const queryClient = new QueryClient();
+  test("when test message do not have psid, we get other error", async () => {
+    const queryClient = new QueryClient();
 
-  //   axiosMock.onPost("/api/courses/post").reply(400, {
-  //     message: " for method parameter type Long is not present",
-  //   });
+    axiosMock.onPost("/api/courses/post").reply(400, {
+      message: " for method parameter type Long is not present",
+    });
 
-  //   render(
-  //     <QueryClientProvider client={queryClient}>
-  //       <MemoryRouter>
-  //         <CoursesCreatePage />
-  //       </MemoryRouter>
-  //     </QueryClientProvider>,
-  //   );
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
 
-  //   expect(
-  //     await screen.findByTestId("CourseForm-enrollCd"),
-  //   ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("CourseForm-enrollCd"),
+    ).toBeInTheDocument();
 
-  //   const psIdField = document.querySelector("#CourseForm-psId");
-  //   const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
-  //   const submitButton = screen.getByTestId("CourseForm-submit");
+    const psIdField = document.querySelector("#CourseForm-psId");
+    const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
+    const submitButton = screen.getByTestId("CourseForm-submit");
 
-  //   fireEvent.change(psIdField, { target: { value: "" } });
-  //   fireEvent.change(enrollCdField, { target: { value: "00026" } });
+    fireEvent.change(psIdField, { target: { value: "" } });
+    fireEvent.change(enrollCdField, { target: { value: "00026" } });
 
-  //   expect(submitButton).toBeInTheDocument();
+    expect(submitButton).toBeInTheDocument();
 
-  //   fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
 
-  //   await screen.findByTestId("PSCourseCreate-Error");
-  //   const PSError = screen.getByTestId("PSCourseCreate-Error");
-  //   expect(PSError).toBeInTheDocument();
+    await screen.findByTestId("PSCourseCreate-Error");
+    const PSError = screen.getByTestId("PSCourseCreate-Error");
+    expect(PSError).toBeInTheDocument();
 
-  //   expect(
-  //     screen.queryByText(
-  //       /Please select a personal schedule or create a new one./,
-  //     ),
-  //   ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /Please select a personal schedule or create a new one./,
+      ),
+    ).not.toBeInTheDocument();
 
-  //   expect(
-  //     screen.queryByText(
-  //       /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
-  //     ),
-  //   ).not.toBeInTheDocument();
-  // });
+    expect(
+      screen.queryByText(
+        /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
+      ),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -110,6 +110,10 @@ describe("CoursesCreatePage tests", () => {
   test("when you input incorrect information, we get an error", async () => {
     const queryClient = new QueryClient();
 
+    // axiosMock.onPost("/api/courses/post").reply(404, {
+    //   message: null,
+    // });
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -125,7 +129,7 @@ describe("CoursesCreatePage tests", () => {
     const submitButton = screen.getByTestId("CourseForm-submit");
 
     fireEvent.change(psIdField, { target: { value: 13 } });
-    fireEvent.change(enrollCdField, { target: { value: "99881" } });
+    fireEvent.change(enrollCdField, { target: { value: '11111' } });
 
     expect(submitButton).toBeInTheDocument();
 
@@ -136,17 +140,11 @@ describe("CoursesCreatePage tests", () => {
     expect(PSError).toBeInTheDocument();
 
     expect(
-      await screen.findByText(
+      screen.queryByText(
         /Please select a personal schedule or create a new one./,
       ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(screen.getByText(/Add Personal Schedule/)).toBeInTheDocument();
-    });
-    const button = screen.getByText(/Add Personal Schedule/);
-    expect(button).toHaveAttribute("href", "/personalschedules/create");
-    expect(button).toHaveAttribute("style", "float: right;");
   });
 
   test("sets schedule and updates localStorage when schedules are available", async () => {
@@ -179,5 +177,110 @@ describe("CoursesCreatePage tests", () => {
         /Please select a personal schedule or create a new one./,
       ),
     ).not.toBeInTheDocument();
+
   });
+
+
+  test("when you did not select schedule, we get an error", async () => {
+    const queryClient = new QueryClient();
+
+    axiosMock.onPost("/api/courses/post").reply(400, {
+      message: "'psId' for method parameter type Long is not present",
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId("CourseForm-enrollCd")).toBeInTheDocument();
+
+    const psIdField = document.querySelector("#CourseForm-psId");
+    const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
+    const submitButton = screen.getByTestId("CourseForm-submit");
+
+    fireEvent.change(psIdField, { target: { value: ''} });
+    fireEvent.change(enrollCdField, { target: { value: "00026" } });
+
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.click(submitButton);
+
+    await screen.findByTestId("PSCourseCreate-Error");
+    const PSError = screen.getByTestId("PSCourseCreate-Error");
+    expect(PSError).toBeInTheDocument();
+
+
+    expect(
+      await screen.findByText(
+        /Please select a personal schedule or create a new one./,
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+        screen.queryByText(
+          /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
+        ),
+      ).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Add Personal Schedule/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Add Personal Schedule/);
+    expect(button).toHaveAttribute("href", "/personalschedules/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("when you did not select schedule, we get an error", async () => {
+    const queryClient = new QueryClient();
+
+    axiosMock.onPost("/api/courses/post").reply(400, {
+      message: " for method parameter type Long is not present",
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId("CourseForm-enrollCd")).toBeInTheDocument();
+
+    const psIdField = document.querySelector("#CourseForm-psId");
+    const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
+    const submitButton = screen.getByTestId("CourseForm-submit");
+
+    fireEvent.change(psIdField, { target: { value: ''} });
+    fireEvent.change(enrollCdField, { target: { value: "00026" } });
+
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.click(submitButton);
+
+    await screen.findByTestId("PSCourseCreate-Error");
+    const PSError = screen.getByTestId("PSCourseCreate-Error");
+    expect(PSError).toBeInTheDocument();
+
+
+    expect(
+      await screen.queryByText(
+        /Please select a personal schedule or create a new one./,
+      ),
+    ).not.toBeInTheDocument();
+
+    expect(
+        screen.queryByText(
+          /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
+        ),
+      ).not.toBeInTheDocument();
+
+  });
+  
+  
 });
+

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -136,7 +136,9 @@ describe("CoursesCreatePage tests", () => {
     expect(PSError).toBeInTheDocument();
 
     expect(
-      await screen.findByText(/Please select a personal schedule or create a new one./),
+      await screen.findByText(
+        /Please select a personal schedule or create a new one./,
+      ),
     ).toBeInTheDocument();
 
     await waitFor(() => {
@@ -173,7 +175,9 @@ describe("CoursesCreatePage tests", () => {
     ).toBeInTheDocument();
     expect(localStorage.getItem("CourseForm-psId")).toBe("17");
     expect(
-        screen.queryByText(/Please select a personal schedule or create a new one./),
+      screen.queryByText(
+        /Please select a personal schedule or create a new one./,
+      ),
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -232,50 +232,50 @@ describe("CoursesCreatePage tests", () => {
     expect(button).toHaveAttribute("style", "float: right;");
   });
 
-  test("when test message do not have psid, we get other error", async () => {
-    const queryClient = new QueryClient();
+  // test("when test message do not have psid, we get other error", async () => {
+  //   const queryClient = new QueryClient();
 
-    axiosMock.onPost("/api/courses/post").reply(400, {
-      message: " for method parameter type Long is not present",
-    });
+  //   axiosMock.onPost("/api/courses/post").reply(400, {
+  //     message: " for method parameter type Long is not present",
+  //   });
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <CoursesCreatePage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+  //   render(
+  //     <QueryClientProvider client={queryClient}>
+  //       <MemoryRouter>
+  //         <CoursesCreatePage />
+  //       </MemoryRouter>
+  //     </QueryClientProvider>,
+  //   );
 
-    expect(
-      await screen.findByTestId("CourseForm-enrollCd"),
-    ).toBeInTheDocument();
+  //   expect(
+  //     await screen.findByTestId("CourseForm-enrollCd"),
+  //   ).toBeInTheDocument();
 
-    const psIdField = document.querySelector("#CourseForm-psId");
-    const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
-    const submitButton = screen.getByTestId("CourseForm-submit");
+  //   const psIdField = document.querySelector("#CourseForm-psId");
+  //   const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
+  //   const submitButton = screen.getByTestId("CourseForm-submit");
 
-    fireEvent.change(psIdField, { target: { value: "" } });
-    fireEvent.change(enrollCdField, { target: { value: "00026" } });
+  //   fireEvent.change(psIdField, { target: { value: "" } });
+  //   fireEvent.change(enrollCdField, { target: { value: "00026" } });
 
-    expect(submitButton).toBeInTheDocument();
+  //   expect(submitButton).toBeInTheDocument();
 
-    fireEvent.click(submitButton);
+  //   fireEvent.click(submitButton);
 
-    await screen.findByTestId("PSCourseCreate-Error");
-    const PSError = screen.getByTestId("PSCourseCreate-Error");
-    expect(PSError).toBeInTheDocument();
+  //   await screen.findByTestId("PSCourseCreate-Error");
+  //   const PSError = screen.getByTestId("PSCourseCreate-Error");
+  //   expect(PSError).toBeInTheDocument();
 
-    expect(
-      screen.queryByText(
-        /Please select a personal schedule or create a new one./,
-      ),
-    ).not.toBeInTheDocument();
+  //   expect(
+  //     screen.queryByText(
+  //       /Please select a personal schedule or create a new one./,
+  //     ),
+  //   ).not.toBeInTheDocument();
 
-    expect(
-      screen.queryByText(
-        /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
-      ),
-    ).not.toBeInTheDocument();
-  });
+  //   expect(
+  //     screen.queryByText(
+  //       /EnrollCd: 00026 is invalid, (enrollCd must be valid, numeric, and no more than five digits)/,
+  //     ),
+  //   ).not.toBeInTheDocument();
+  // });
 });

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -134,6 +134,17 @@ describe("CoursesCreatePage tests", () => {
     await screen.findByTestId("PSCourseCreate-Error");
     const PSError = screen.getByTestId("PSCourseCreate-Error");
     expect(PSError).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(/Please select a personal schedule or create a new one./),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Add Personal Schedule/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Add Personal Schedule/);
+    expect(button).toHaveAttribute("href", "/personalschedules/create");
+    expect(button).toHaveAttribute("style", "float: right;");
   });
 
   test("sets schedule and updates localStorage when schedules are available", async () => {
@@ -161,5 +172,8 @@ describe("CoursesCreatePage tests", () => {
       await screen.findByTestId("CourseForm-enrollCd"),
     ).toBeInTheDocument();
     expect(localStorage.getItem("CourseForm-psId")).toBe("17");
+    expect(
+        screen.queryByText(/Please select a personal schedule or create a new one./),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Add a more descriptive error message. When user want to add a course without any schedule, it will report error.

For bonus part, I add a button to create a new personal schedule. This button will only show up, when the page report error.

<img width="1171" alt="Error" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-4/assets/129719123/ef126f4a-f148-4a74-b0fc-a96166f787ef">

Dokku dev:
https://project-samanthwest.dokku-08.cs.ucsb.edu

Closes #5 

